### PR TITLE
Dev

### DIFF
--- a/src/components/Admin/Admin.js
+++ b/src/components/Admin/Admin.js
@@ -9,14 +9,6 @@ import AuctionResultsPanelSimple from './AuctionResultsPanelSimple.js';
 
 const POSTS_PER_PAGE = 15;
 
-/* Which page numbers to render.
- *
- * Narrow screens can't fit thirty buttons, so the run collapses to
- * first / neighbours / last with ellipses. The old version decided this
- * with a media query hook and kept two near-identical branches; the
- * window is the same shape at every width, only its size differs, so
- * CSS handles the fit and this just caps how many numbers exist.
- */
 const buildPageWindow = (currentPage, totalPages) => {
   if (totalPages <= 7) {
     return Array.from({ length: totalPages }, (_unused, index) => index + 1);
@@ -40,9 +32,6 @@ const buildPageWindow = (currentPage, totalPages) => {
 
 export default function Admin() {
   const { posts, loading, setPosts } = usePosts();
-  // Rolled once at mount, like the accordions this replaced: below the
-  // sidebar breakpoint the panels start collapsed so the post list isn't
-  // buried under a twenty-row table, and above it they're the rail.
   const [railStartsOpen] = useState(() => window.matchMedia('(min-width: 1200px)').matches);
   const [selectedCategory, setSelectedCategory] = useState(null);
   // Admin filter state for post visibility

--- a/src/components/Inventory/Inventory.css
+++ b/src/components/Inventory/Inventory.css
@@ -1,12 +1,9 @@
-/* Inventory by category.
- *
- * A dense numeric table, so it gets hairline separators rather than a
- * grid of borders: the columns already align, and boxing every cell was
- * fighting the numbers for attention.
- */
-
 .slg-inventory {
   overflow-x: auto;
+
+  --slg-stock-out: #ff5f57;
+  --slg-stock-low: #f0b429;
+  --slg-stock-ok: #46c07a;
 }
 
 .slg-inventory-table {
@@ -17,12 +14,43 @@
   color: var(--slg-ink);
 }
 
+.slg-inventory-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  padding-bottom: 0.85rem;
+}
+
 .slg-inventory-caption {
-  padding: 0 0 0.85rem;
+  margin: 0 0 0.6rem;
   text-align: left;
   font-size: 0.75rem;
   line-height: 1.45;
   color: var(--slg-dim);
+}
+
+.slg-inventory-toggle {
+  flex: 0 0 auto;
+  padding: 0.3rem 0.6rem;
+  font-family: var(--slg-body);
+  font-size: 0.6875rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  white-space: nowrap;
+  color: var(--slg-dim);
+  background: none;
+  border: 1px solid var(--slg-edge);
+  border-radius: 999px;
+  cursor: pointer;
+}
+
+.slg-inventory-toggle:hover {
+  color: var(--slg-ink);
+}
+
+.slg-inventory-toggle--on {
+  color: var(--slg-ink);
+  background: var(--slg-lift-hover);
 }
 
 .slg-inventory-table th,
@@ -54,56 +82,49 @@
 /* The category name is the control, so it fills the cell rather than
    relying on a click handler bolted to the row. */
 .slg-inventory-category {
-  display: flex;
-  align-items: center;
-  gap: 0.55rem;
+  display: block;
   width: 100%;
   padding: 0.15rem 0;
   font-family: var(--slg-body);
   font-size: 0.8125rem;
+  font-weight: inherit;
   text-align: left;
-  color: var(--slg-ink);
+  color: inherit;
   background: none;
   border: none;
   cursor: pointer;
-  transition: color 160ms ease;
 }
 
-.slg-inventory-category:hover {
-  color: var(--slg-flame);
+.slg-inventory-count {
+  font-size: 0.9375rem;
+  font-weight: 600;
 }
 
-.slg-inventory-dot {
-  flex: 0 0 auto;
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: var(--slg-dim);
+.slg-inventory-row--ok {
+  color: var(--slg-stock-ok);
 }
 
-.slg-inventory-dot--ok {
-  background: #3f6f4a;
+.slg-inventory-row--low {
+  color: var(--slg-stock-low);
 }
 
-.slg-inventory-dot--low {
-  background: #8a7530;
+.slg-inventory-row--out {
+  color: var(--slg-stock-out);
 }
 
-.slg-inventory-dot--out {
-  background: var(--slg-alert);
+/* An empty category is the row you are hunting for, so it is also the
+   only one set in bold. */
+.slg-inventory-row--out .slg-inventory-category {
+  font-weight: 600;
 }
 
 .slg-inventory-table tbody tr:hover {
-  background: var(--slg-lift-hover);
+  background: rgba(255, 255, 255, 0.035);
 }
 
-.slg-inventory-row--selected {
+.slg-inventory-row--selected,
+.slg-inventory-table tbody tr.slg-inventory-row--selected:hover {
   background: var(--slg-lift-hover);
-  box-shadow: inset 2px 0 0 var(--slg-flame);
-}
-
-.slg-inventory-row--selected .slg-inventory-category {
-  color: var(--slg-flame);
 }
 
 /* ---------- footer totals ---------- */

--- a/src/components/Inventory/Inventory.js
+++ b/src/components/Inventory/Inventory.js
@@ -1,32 +1,55 @@
+import { useState } from 'react';
 import './Inventory.css';
 import { CATEGORY_NAMES, calculateInventoryTotals, formatMoney } from './inventoryTotals.js';
 
-/* Stock level, read at a glance from the count column.
- *
- * The old version coloured a category's whole row red at zero and purple
- * at five or more, which put the loudest colour on the least urgent row.
- * Now it's a single dot and only a genuinely empty category is allowed
- * to be alarming. */
 const stockLevel = (count) => {
   if (count === 0) return 'out';
   if (count <= 2) return 'low';
   return 'ok';
 };
 
+const STOCK_LEVEL_LABELS = {
+  out: 'out of stock',
+  low: 'low stock',
+  ok: 'in stock',
+};
+
 const Inventory = ({ posts, onCategorySelect, selectedCategory }) => {
-  const totals = calculateInventoryTotals(posts);
+  const [includeHidden, setIncludeHidden] = useState(false);
+  const totals = calculateInventoryTotals(posts, { includeHidden });
 
   return (
     <div className="slg-inventory">
+      <p className="slg-inventory-caption">
+        What is on the shelf right now — sold and deleted pieces are left out. Tap a category to
+        filter the list.
+      </p>
+
+      <div className="slg-inventory-controls">
+        <button
+          type="button"
+          className={`slg-inventory-toggle${selectedCategory === null ? ' slg-inventory-toggle--on' : ''}`}
+          aria-pressed={selectedCategory === null}
+          onClick={() => onCategorySelect(null)}
+        >
+          All categories
+        </button>
+        <button
+          type="button"
+          className={`slg-inventory-toggle${includeHidden ? ' slg-inventory-toggle--on' : ''}`}
+          aria-pressed={includeHidden}
+          onClick={() => setIncludeHidden((isOn) => !isOn)}
+        >
+          Count hidden
+        </button>
+      </div>
+
       <table className="slg-inventory-table">
-        <caption className="slg-inventory-caption">
-          Tap a category to filter the list. Values use the sale price where one is set.
-        </caption>
         <thead>
           <tr>
             <th scope="col">Category</th>
             <th scope="col" className="slg-inventory-numeric">
-              Qty
+              In stock
             </th>
             <th scope="col" className="slg-inventory-numeric">
               Value
@@ -35,13 +58,17 @@ const Inventory = ({ posts, onCategorySelect, selectedCategory }) => {
         </thead>
         <tbody>
           {CATEGORY_NAMES.map((categoryName) => {
-            const count = totals.countByCategory[categoryName];
+            const count = totals.inStockCountByCategory[categoryName];
+            const level = stockLevel(count);
+            const rowClasses = [
+              `slg-inventory-row--${level}`,
+              selectedCategory === categoryName ? 'slg-inventory-row--selected' : '',
+            ]
+              .filter(Boolean)
+              .join(' ');
 
             return (
-              <tr
-                key={categoryName}
-                className={selectedCategory === categoryName ? 'slg-inventory-row--selected' : ''}
-              >
+              <tr key={categoryName} className={rowClasses}>
                 <th scope="row">
                   <button
                     type="button"
@@ -49,19 +76,28 @@ const Inventory = ({ posts, onCategorySelect, selectedCategory }) => {
                     aria-pressed={selectedCategory === categoryName}
                     onClick={() => onCategorySelect(categoryName)}
                   >
-                    <span className={`slg-inventory-dot slg-inventory-dot--${stockLevel(count)}`} />
                     {categoryName}
+                    <span className="slg-visually-hidden">— {STOCK_LEVEL_LABELS[level]}</span>
                   </button>
                 </th>
-                <td className="slg-inventory-numeric">{count}</td>
+                <td className="slg-inventory-numeric slg-inventory-count">{count}</td>
                 <td className="slg-inventory-numeric">
-                  {formatMoney(totals.discountedTotalByCategory[categoryName])}
+                  {formatMoney(totals.inStockDiscountedTotalByCategory[categoryName])}
                 </td>
               </tr>
             );
           })}
         </tbody>
         <tfoot>
+          <tr>
+            <th scope="row">In stock</th>
+            <td className="slg-inventory-numeric">{totals.inStockCategorisedCount}</td>
+            <td className="slg-inventory-numeric">
+              <span className="slg-inventory-figure">
+                {formatMoney(totals.inStockCategorisedTotal)}
+              </span>
+            </td>
+          </tr>
           <tr>
             <th scope="row">All pieces</th>
             <td className="slg-inventory-numeric">{totals.categorisedCount}</td>
@@ -85,14 +121,11 @@ const Inventory = ({ posts, onCategorySelect, selectedCategory }) => {
             </td>
           </tr>
           <tr>
-            <th scope="row">For sale</th>
-            <td className="slg-inventory-numeric">{totals.forSaleCount}</td>
+            <th scope="row">Hidden</th>
+            <td className="slg-inventory-numeric">{totals.hiddenCount}</td>
             <td className="slg-inventory-numeric">
-              <span className="slg-inventory-figure">
-                {formatMoney(totals.forSaleDiscountedTotal)}
-              </span>
               <span className="slg-inventory-figure-note">
-                {formatMoney(totals.forSaleRegularTotal)} at full price
+                {includeHidden ? 'counted above' : 'not counted above'}
               </span>
             </td>
           </tr>

--- a/src/components/Inventory/inventoryTotals.js
+++ b/src/components/Inventory/inventoryTotals.js
@@ -27,15 +27,22 @@ export const CATEGORY_NAMES = [
   'Misc',
 ];
 
-export const calculateInventoryTotals = (posts) => {
+const isInStock = (post, includeHidden) =>
+  !post.sold && !post.isDeleted && (includeHidden || !post.hide);
+
+export const calculateInventoryTotals = (posts, { includeHidden = false } = {}) => {
   const countByCategory = {};
   const regularTotalByCategory = {};
   const discountedTotalByCategory = {};
+  const inStockCountByCategory = {};
+  const inStockDiscountedTotalByCategory = {};
 
   for (const categoryName of CATEGORY_NAMES) {
     countByCategory[categoryName] = 0;
     regularTotalByCategory[categoryName] = 0;
     discountedTotalByCategory[categoryName] = 0;
+    inStockCountByCategory[categoryName] = 0;
+    inStockDiscountedTotalByCategory[categoryName] = 0;
   }
 
   let regularTotal = 0;
@@ -44,10 +51,14 @@ export const calculateInventoryTotals = (posts) => {
   let soldRegularTotal = 0;
   let soldDiscountedTotal = 0;
   let hiddenCount = 0;
+  let inStockCount = 0;
+  let inStockRegularTotal = 0;
+  let inStockDiscountedTotal = 0;
 
   for (const post of posts) {
     const regularPrice = parseFloat(post.price) || 0;
     const effectivePrice = post.discountedPrice ? parseFloat(post.discountedPrice) : regularPrice;
+    const inStock = isInStock(post, includeHidden);
 
     regularTotal += regularPrice;
     discountedTotal += effectivePrice;
@@ -58,6 +69,17 @@ export const calculateInventoryTotals = (posts) => {
       countByCategory[post.category] += 1;
       regularTotalByCategory[post.category] += regularPrice;
       discountedTotalByCategory[post.category] += effectivePrice;
+
+      if (inStock) {
+        inStockCountByCategory[post.category] += 1;
+        inStockDiscountedTotalByCategory[post.category] += effectivePrice;
+      }
+    }
+
+    if (inStock) {
+      inStockCount += 1;
+      inStockRegularTotal += regularPrice;
+      inStockDiscountedTotal += effectivePrice;
     }
 
     if (post.sold) {
@@ -76,10 +98,24 @@ export const calculateInventoryTotals = (posts) => {
     0
   );
 
+  const inStockCategorisedCount = Object.values(inStockCountByCategory).reduce(
+    (runningTotal, count) => runningTotal + count,
+    0
+  );
+
+  const inStockCategorisedTotal = Object.values(inStockDiscountedTotalByCategory).reduce(
+    (runningTotal, amount) => runningTotal + amount,
+    0
+  );
+
   return {
     countByCategory,
     regularTotalByCategory,
     discountedTotalByCategory,
+    inStockCountByCategory,
+    inStockDiscountedTotalByCategory,
+    inStockCategorisedCount,
+    inStockCategorisedTotal,
     categorisedCount,
     regularTotal,
     discountedTotal,
@@ -87,9 +123,9 @@ export const calculateInventoryTotals = (posts) => {
     soldRegularTotal,
     soldDiscountedTotal,
     hiddenCount,
-    forSaleCount: categorisedCount - soldCount,
-    forSaleRegularTotal: regularTotal - soldRegularTotal,
-    forSaleDiscountedTotal: discountedTotal - soldDiscountedTotal,
+    forSaleCount: inStockCount,
+    forSaleRegularTotal: inStockRegularTotal,
+    forSaleDiscountedTotal: inStockDiscountedTotal,
   };
 };
 


### PR DESCRIPTION
# Inventory panel: show what's actually in stock, restore at-a-glance stock colour

## Summary
The admin Inventory panel was counting every post in a category — sold, deleted and hidden included — which made it useless for its actual job: deciding what to make at the start of the day. Category rows now count only pieces that are physically available, and stock level is once again carried by the row's text colour rather than a 6px dot. A visible "All categories" control brings back the way out of a category filter.

## Changes

**In-stock definition (`src/components/Inventory/inventoryTotals.js`)**
- Added `isInStock(post, includeHidden)`: excludes `sold` and `isDeleted` always, and `hide` by default.
- `calculateInventoryTotals` takes an `{ includeHidden }` option and returns `inStockCountByCategory`, `inStockDiscountedTotalByCategory`, `inStockCategorisedCount` and `inStockCategorisedTotal` alongside the existing all-posts figures.
- `forSaleCount` / `forSaleRegularTotal` / `forSaleDiscountedTotal` are now accumulated from in-stock posts instead of being derived as `total − sold`, so they no longer count deleted or hidden pieces. This changes the Admin dashboard's "For sale" and "Stock value" tiles.

**Inventory table (`src/components/Inventory/Inventory.js`, `Inventory.css`)**
- Category rows read the in-stock buckets; the quantity column header is now "In stock".
- Stock level colours the category name and count (red at 0, amber at 1–2, green at 3+); the status dot is gone and empty categories are additionally set in bold.
- Added an "All categories" chip that clears the category filter, and a "Count hidden" chip that recomputes the table with hidden pieces included.
- Hover and selection are background-only, so a healthy row can never flash a colour that reads as an alarm.
- Footer gained an "In stock" total row and a "Hidden" row that states whether hidden pieces are being counted; the old "For sale" row was replaced.

**Comment cleanup (`src/components/Admin/Admin.js`)**
- Removed the block comments above `buildPageWindow` and `railStartsOpen`. No behaviour change.

## Testing
- No automated tests were added or changed in this set; verification is manual against the admin dashboard (category counts vs. sold/hidden/deleted posts, the two chips, hover and selection states).