### PR TITLE
Dev

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -30,6 +30,7 @@ import { useProfileStore } from './stores/profileStore.js';
 import { useMessaging } from './hooks/useWebSocket.js';
 import { getMyMessages } from './services/fetch-messages.js';
 import AdminSales from './components/Admin/AdminSales/AdminSales.js';
+import DisplayGallery from './components/DisplayGallery/DisplayGallery.js';
 
 const mainTheme = createTheme({
   palette: {
@@ -209,6 +210,7 @@ function App() {
           <Routes>
             <Route path="/auth/:type" element={<Auth />} />
             <Route path="/" element={<MainGallery />} />
+            <Route path="/gallery" element={<DisplayGallery />} />
             <Route path="/about-me" element={<AboutMe />} />
             <Route path="/auctions" element={<AuctionList />} />
             <Route path="/auctions/:id" element={<AuctionDetail />} />

--- a/src/App.js
+++ b/src/App.js
@@ -2,6 +2,7 @@ import { Route, Routes, useLocation, useNavigate } from 'react-router-dom';
 import './App.css';
 import { useUserStore } from './stores/userStore.js';
 import Auth from './components/Auth/Auth.js';
+import ForgotPassword from './components/ForgotPassword/ForgotPassword.js';
 import Admin from './components/Admin/Admin.js';
 import Header from './components/Header/Header.js';
 import NewPost from './components/NewPost/NewPost.js';
@@ -208,9 +209,10 @@ function App() {
         <ToastContainer position="top-center" />
         <ThemeProvider theme={theme}>
           <Routes>
+            <Route path="/auth/forgot-password" element={<ForgotPassword />} />
             <Route path="/auth/:type" element={<Auth />} />
             <Route path="/" element={<MainGallery />} />
-            <Route path="/gallery" element={<DisplayGallery />} />
+            {/* <Route path="/gallery" element={<DisplayGallery />} /> */}
             <Route path="/about-me" element={<AboutMe />} />
             <Route path="/auctions" element={<AuctionList />} />
             <Route path="/auctions/:id" element={<AuctionDetail />} />

--- a/src/components/Auth/Auth.css
+++ b/src/components/Auth/Auth.css
@@ -682,3 +682,23 @@
     top: 200px;
   }
 }
+
+.forgot-password-link {
+  color: rgba(255, 255, 255, 0.8);
+  text-align: center;
+  margin-top: 10px;
+  text-decoration: underline;
+  display: block;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 1s ease;
+}
+
+.forgot-password-link.visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.forgot-password-link:hover {
+  color: #ffffff;
+}

--- a/src/components/Auth/Auth.js
+++ b/src/components/Auth/Auth.js
@@ -537,6 +537,14 @@ export default function Auth() {
                 <button className="button-auth" onClick={isSignIn ? submitAuth : handleSignupClick}>
                   {isSignIn ? 'Sign In' : 'Sign Up'}
                 </button>
+                <Link
+                  className={`forgot-password-link ${type === 'sign-in' ? 'visible' : ''}`}
+                  to="/auth/forgot-password"
+                  tabIndex={type === 'sign-in' ? 0 : -1}
+                  aria-hidden={type !== 'sign-in'}
+                >
+                  Forgot password?
+                </Link>
                 {isSignIn && shouldOfferResend && (
                   <button
                     className="button-auth"

--- a/src/components/DisplayGallery/DisplayGallery.js
+++ b/src/components/DisplayGallery/DisplayGallery.js
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function DisplayGallery() {
+  return <div style={{ position: 'absolute', top: '500px' }}>GALLERY </div>;
+}

--- a/src/components/ForgotPassword/ForgotPassword.css
+++ b/src/components/ForgotPassword/ForgotPassword.css
@@ -1,0 +1,42 @@
+.forgot-password-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 70vh;
+  padding: 20px;
+}
+
+.forgot-password-card {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  max-width: 420px;
+}
+
+.forgot-password-title {
+  color: white;
+  margin-bottom: 0.5rem;
+  text-align: center;
+}
+
+.forgot-password-copy {
+  color: rgba(255, 255, 255, 0.8);
+  margin-bottom: 1.5rem;
+  text-align: center;
+  line-height: 1.5;
+}
+
+.forgot-password-sent {
+  color: rgba(255, 255, 255, 0.9);
+  text-align: center;
+  line-height: 1.6;
+}
+
+.forgot-password-back {
+  color: rgba(255, 255, 255, 0.8);
+  text-align: center;
+  margin-top: 1.5rem;
+  text-decoration: underline;
+  display: block;
+}

--- a/src/components/ForgotPassword/ForgotPassword.js
+++ b/src/components/ForgotPassword/ForgotPassword.js
@@ -1,0 +1,102 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { toast } from 'react-toastify';
+import { requestPasswordReset } from '../../services/fetch-utils.js';
+import '../Auth/Auth.css';
+import './ForgotPassword.css';
+
+const ForgotPassword = () => {
+  const [email, setEmail] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [hasSubmitted, setHasSubmitted] = useState(false);
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+
+    const normalizedEmail = email.trim();
+
+    const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailPattern.test(normalizedEmail)) {
+      toast.warn('Enter a valid email address', {
+        theme: 'dark',
+        draggable: true,
+        draggablePercent: 60,
+        autoClose: 5000,
+      });
+      return;
+    }
+
+    try {
+      setSubmitting(true);
+      await requestPasswordReset(normalizedEmail);
+      setHasSubmitted(true);
+    } catch (error) {
+      if (error?.status === 429) {
+        toast.warn('Too many requests. Please try again later.', {
+          theme: 'colored',
+          autoClose: 6000,
+        });
+      } else {
+        toast.error(error.message || 'Failed to request a password reset.', {
+          theme: 'colored',
+          autoClose: 5000,
+        });
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="forgot-password-container">
+      <div className="forgot-password-card">
+        <h2 className="forgot-password-title">Reset your password</h2>
+
+        {hasSubmitted ? (
+          <>
+            <p className="forgot-password-sent">
+              If an account exists for that address, a password reset email is on its way. The link
+              expires in 30 minutes.
+            </p>
+            <Link className="forgot-password-back" to="/auth/sign-in">
+              Back to sign in
+            </Link>
+          </>
+        ) : (
+          <>
+            <p className="forgot-password-copy">
+              Enter the email address on your account and we&apos;ll send you a link to set a new
+              password.
+            </p>
+            <form onSubmit={handleSubmit}>
+              <input
+                className="input-auth"
+                type="email"
+                id="forgot-password-email"
+                name="email"
+                placeholder="enter your email address"
+                value={email}
+                onChange={(event) => setEmail(event.target.value)}
+                maxLength={101}
+                required
+                inputMode="email"
+                autoComplete="email"
+                autoCapitalize="none"
+                autoCorrect="off"
+                spellCheck={false}
+              />
+              <button className="button-auth" type="submit" disabled={submitting}>
+                {submitting ? 'Sending...' : 'Send reset link'}
+              </button>
+            </form>
+            <Link className="forgot-password-back" to="/auth/sign-in">
+              Back to sign in
+            </Link>
+          </>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default ForgotPassword;

--- a/src/components/Menu/Menu.js
+++ b/src/components/Menu/Menu.js
@@ -88,7 +88,10 @@ export default function Menu({ handleClick, closeMenu }) {
             </span>
           </div>
         )}
-        <NavLink className="menu-new-link" to="/" title="Gallery" onClick={handleLinkClick}>
+        <NavLink className="menu-new-link" to="/" title="Shop" onClick={handleLinkClick}>
+          Shop
+        </NavLink>{' '}
+        <NavLink className="menu-new-link" to="/gallery" title="Gallery" onClick={handleLinkClick}>
           Gallery
         </NavLink>{' '}
         <div style={{ position: 'relative', padding: '0' }}>

--- a/src/components/Menu/Menu.js
+++ b/src/components/Menu/Menu.js
@@ -89,11 +89,11 @@ export default function Menu({ handleClick, closeMenu }) {
           </div>
         )}
         <NavLink className="menu-new-link" to="/" title="Shop" onClick={handleLinkClick}>
-          Shop
+          Available Work
         </NavLink>{' '}
-        <NavLink className="menu-new-link" to="/gallery" title="Gallery" onClick={handleLinkClick}>
+        {/* <NavLink className="menu-new-link" to="/gallery" title="Gallery" onClick={handleLinkClick}>
           Gallery
-        </NavLink>{' '}
+        </NavLink>{' '} */}
         <div style={{ position: 'relative', padding: '0' }}>
           <NavLink className="menu-new-link" to="/auctions" onClick={handleAuctionsClick}>
             Auctions

--- a/src/services/fetch-utils.js
+++ b/src/services/fetch-utils.js
@@ -162,6 +162,35 @@ export async function resendVerification(email) {
   }
 }
 
+// Request a password reset email
+export async function requestPasswordReset(email) {
+  try {
+    const resp = await fetch(`${BASE_URL}/api/v1/users/forgot-password`, {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+      },
+      credentials: 'include',
+      body: JSON.stringify({ email }),
+    });
+
+    const data = await resp.json().catch(() => ({}));
+
+    if (!resp.ok) {
+      const err = new Error(data.message || 'Failed to request a password reset');
+      err.status = resp.status;
+      if (data && data.code) err.code = data.code;
+      throw err;
+    }
+
+    return data; // { message }
+  } catch (error) {
+    console.error('Problem requesting password reset: ', error.message);
+    throw error;
+  }
+}
+
 export async function signOutUser() {
   try {
     const resp = await fetch(`${BASE_URL}/api/v1/users/sessions`, {


### PR DESCRIPTION
# Add forgot-password request form

## Summary
Adds the frontend request half of a password-reset flow: a form that calls the backend's `/forgot-password` endpoint and shows a generic confirmation state. Does not include the reset-confirmation page that would consume the emailed token and let a user set a new password — that lands with the backend confirmation endpoint in a later PR.

## Changes
- `src/services/fetch-utils.js` adds `requestPasswordReset(email)`, POSTing to `/api/v1/users/forgot-password`.
- New `src/components/ForgotPassword/ForgotPassword.js` (+ `.css`) render the request form and a generic "check your email" confirmation state, with its own 429 handling.
- `src/components/Auth/Auth.js` adds a "Forgot password?" link on the sign-in form, kept mounted at all times and faded in/out via CSS opacity (was previously conditionally mounted, which caused a layout shift between sign-in and sign-up).
- `src/components/Auth/Auth.css` adds the fade transition for the new link.
- `src/App.js` wires up `/auth/forgot-password`, registered before the existing `/auth/:type` catch-all.

## Testing
- Manually verified: link shows only on sign-in, no vertical shift when toggling sign-in/sign-up, fade transition renders smoothly.

## Follow-up
- Depends on the backend PR (`/forgot-password` endpoint).
- Reset-confirmation page (consumes the token) isn't built yet.