### PR TITLE
Dev

### DIFF
--- a/src/components/Admin/Admin.js
+++ b/src/components/Admin/Admin.js
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { usePosts } from '../../hooks/usePosts.js';
 import PostCard from '../PostCard/PostCard.js';
 import './Admin.css';
@@ -34,6 +34,7 @@ export default function Admin() {
   const { posts, loading, setPosts } = usePosts();
   const [railStartsOpen] = useState(() => window.matchMedia('(min-width: 1200px)').matches);
   const [selectedCategory, setSelectedCategory] = useState(null);
+  const mainRef = useRef(null);
   // Admin filter state for post visibility
   const [showRegular, setShowRegular] = useState(true);
   const [showHidden, setShowHidden] = useState(true);
@@ -43,6 +44,14 @@ export default function Admin() {
   const handleCategorySelect = (category) => {
     setSelectedCategory(category);
     setCurrentPage(1);
+  };
+
+  // Below 1200px the inventory panel sits underneath the post list
+  const handleRailCategorySelect = (category) => {
+    handleCategorySelect(category);
+    if (!window.matchMedia('(min-width: 1200px)').matches) {
+      mainRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
   };
 
   if (loading) {
@@ -105,7 +114,7 @@ export default function Admin() {
       </div>
 
       <div className="slg-admin-body">
-        <main className="slg-admin-main">
+        <main className="slg-admin-main" ref={mainRef}>
           <div className="slg-admin-toolbar">
             <div className="slg-chips" role="group" aria-label="Show posts by visibility">
               {visibilityFilters.map((filter) => (
@@ -215,7 +224,7 @@ export default function Admin() {
               <Inventory
                 posts={posts}
                 selectedCategory={selectedCategory}
-                onCategorySelect={handleCategorySelect}
+                onCategorySelect={handleRailCategorySelect}
               />
             </div>
           </details>

--- a/src/components/Admin/AdminSales/GallerySalesPanel.js
+++ b/src/components/Admin/AdminSales/GallerySalesPanel.js
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo, useRef } from 'react';
 import { useLocation } from 'react-router-dom';
 import { toast } from 'react-toastify';
 import './AdminSales.css';
@@ -23,6 +23,7 @@ export default function GallerySalesPanel() {
   const [selectedUser, setSelectedUser] = useState(null);
   const [showUserResults, setShowUserResults] = useState(false);
   const [prefillApplied, setPrefillApplied] = useState(false);
+  const salesPanelRef = useRef(null);
   const { posts } = usePosts();
 
   // Modal state for finding post
@@ -70,6 +71,15 @@ export default function GallerySalesPanel() {
   };
 
   // handle selecting an existing sale
+  // At 768px and below the detail panel stacks under a list that is already
+  // 75dvh tall, so whatever opens there lands well below the fold
+  const revealDetailPanelOnMobile = () => {
+    if (window.matchMedia('(min-width: 769px)').matches) return;
+    requestAnimationFrame(() => {
+      salesPanelRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    });
+  };
+
   const handleSelectSale = (saleId) => {
     setIsCreatingSale(false);
     setSelectedSale(saleId);
@@ -78,6 +88,8 @@ export default function GallerySalesPanel() {
     if (sale) {
       setTrackingInput(sale.tracking_number || '');
     }
+
+    revealDetailPanelOnMobile();
   };
 
   // handle saving tracking number
@@ -429,6 +441,7 @@ export default function GallerySalesPanel() {
                 setSelectedUser(null);
                 setSearchTerm('');
                 setDebouncedTerm('');
+                revealDetailPanelOnMobile();
               }}
             >
               Add Sale
@@ -487,7 +500,7 @@ export default function GallerySalesPanel() {
             </div>
 
             {/* Sale detail panel */}
-            <div className="sales-panel">
+            <div className="sales-panel" ref={salesPanelRef}>
               {isCreatingSale ? (
                 <div className="sales-detail">
                   <h2>Create New Sale</h2>

--- a/src/components/AuctionList/AuctionCard.js
+++ b/src/components/AuctionList/AuctionCard.js
@@ -400,9 +400,11 @@ export default function AuctionCard({ auction }) {
           >
             {user && isAdmin && (
               <>
-                <button className="swap-auction-icon-btn" onClick={handleOpenSwapModal}>
-                  ↳↰
-                </button>
+                {(isActive || bids.length === 0) && (
+                  <button className="swap-auction-icon-btn" onClick={handleOpenSwapModal}>
+                    ↳↰
+                  </button>
+                )}
                 <button className="edit-auction-icon-btn" onClick={handleEdit}>
                   ✎
                 </button>

--- a/src/components/AuctionList/AuctionList.js
+++ b/src/components/AuctionList/AuctionList.js
@@ -154,9 +154,10 @@ export default function AuctionList() {
   }, [lastAuctionExtended]);
 
   useEffect(() => {
+    if (!user) return;
     markAuctionsRead();
     //eslint-disable-next-line
-  }, []);
+  }, [user]);
 
   if (loading) {
     return (

--- a/src/hooks/useGalleryPost.js
+++ b/src/hooks/useGalleryPost.js
@@ -22,7 +22,9 @@ export function useGalleryPost(id) {
       try {
         const data = await getGalleryPostDetail(id);
         if (!data) {
-          history.push('/');
+          setLoading(false);
+          navigate('/');
+          return;
         }
         const additionalImagesGallery = await getAdditionalImageUrlsPublicIdsGallery(id);
         const additionalImageUrlsPublicIds = additionalImagesGallery.map(

--- a/src/hooks/useWebSocket.js
+++ b/src/hooks/useWebSocket.js
@@ -1,18 +1,23 @@
 import { useEffect, useRef, useState } from 'react';
 import websocketService from '../services/websocket.js';
 import { useLocation } from 'react-router-dom';
+import { useUserStore } from '../stores/userStore.js';
 
 export const useWebSocket = () => {
   const [isConnected, setIsConnected] = useState(false);
   const [socketId, setSocketId] = useState(null);
   const listenersRef = useRef(new Map());
+  const user = useUserStore((state) => state.user);
 
   useEffect(() => {
-    // Connect to WebSocket
+    // Connect only once there is a session; the handshake needs the cookie.
+    if (!user) return;
     if (!websocketService.socket || !websocketService.isConnected) {
       websocketService.connect();
     }
+  }, [user]);
 
+  useEffect(() => {
     // Set up connection status listener
     const handleConnection = (data) => {
       setIsConnected(data.connected);

--- a/src/services/fetch-utils.js
+++ b/src/services/fetch-utils.js
@@ -611,6 +611,10 @@ export async function getGalleryPostDetail(id) {
       },
     });
 
+    if (resp.status === 404) {
+      return null;
+    }
+
     const msg = await resp.json();
     return msg;
   } catch (error) {

--- a/src/services/websocket.js
+++ b/src/services/websocket.js
@@ -16,6 +16,10 @@ class WebSocketService {
       return this.socket;
     }
 
+    if (!useUserStore.getState().user) {
+      return null;
+    }
+
     try {
       this.socket = io(BASE_URL, {
         withCredentials: true,


### PR DESCRIPTION
# Handle gallery 404s, silence signed-out API calls, fix two dead-looking mobile controls

## Summary
Clears four items from the 2026-08-22 E2E report plus two mobile UI bugs. Signed-out visitors were firing authenticated calls, the gallery detail hook was throwing on a dead react-router v5 call, and two admin controls appeared to do nothing on a phone because the state they changed rendered below the fold.

Depends on the backend PR that makes `/api/v1/main-gallery/:id` return real 404s. The gallery changes here are inert without it.

## Changes

**Gallery post 404s**
- `src/services/fetch-utils.js` — `getGalleryPostDetail` returns `null` on a 404 rather than parsing the error body as if it were a post.
- `src/hooks/useGalleryPost.js` — replaced a react-router v5 leftover, `history.push('/')`. There is no `history` import in the file, so it resolved to `window.history`, threw a `TypeError` into the surrounding catch, and surfaced as a misleading "Error fetching gallery post" toast. It now clears loading, calls `navigate('/')`, and returns.

**Signed-out console noise**
- `src/components/AuctionList/AuctionList.js` — `markAuctionsRead()` is gated on `user`, so visiting `/auctions` signed out no longer fires a `PATCH` that takes a 401.
- `src/services/websocket.js` and `src/hooks/useWebSocket.js` — the socket connect is gated on a known session. The connect moved into its own effect keyed on `user`, and `connect()` itself bails when the store has no user. `App.js` calls `useMessaging()` unconditionally, so every signed-out page load was opening a handshake the server immediately rejected.

**Auction swap**
- `src/components/AuctionList/AuctionCard.js` — the swap-to-gallery-post button is hidden once an auction has ended with bids. The swap discards the winner and the sale record, and there is nothing to swap back for at that point.

**Mobile admin controls**
- `src/components/Admin/Admin.js` — below 1200px the inventory panel stacks under the post list, so picking a category filtered a list that was entirely off-screen. Selecting from the rail now scrolls the list into view.
- `src/components/Admin/AdminSales/GallerySalesPanel.js` — same problem for Add Sale and for opening an existing sale. `.sales-list` is `max-height: 75dvh` and the detail panel stacks beneath it at 768px and below, so both paths now scroll the panel into view through a shared `revealDetailPanelOnMobile`.

## Testing
No new tests. Verification is manual, on a narrow viewport for the two admin controls and with the console open for the signed-out pages: `/auctions` signed out logs no 401 and no WebSocket authentication error, a bad gallery url redirects home instead of spinning, and an ended auction with bids shows no swap button.