### PR TITLE
Dev

### DIFF
--- a/src/components/Admin/AdminSales/AdminSales.css
+++ b/src/components/Admin/AdminSales/AdminSales.css
@@ -1,468 +1,911 @@
-.admin-sales-wrapper {
-  width: 60%;
-  margin: 90px auto 0 auto;
-  border: 1px solid #0026a153;
-  background-color: black;
-  height: fit-content;
+.slg-sales {
+  padding-top: var(--slg-header-height);
+  padding-bottom: 4rem;
+  background: var(--slg-void);
+  color: var(--slg-ink);
+  font-family: var(--slg-body);
+  text-align: left;
 }
 
-.admin-sales-container {
+/* ---------- head ---------- */
+
+.slg-sales-head {
   display: flex;
-  justify-content: center;
-  width: 100%;
-  color: #fff;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 1.75rem var(--slg-gutter-tight) 1.25rem;
 }
 
-.admin-sales-content {
-  width: 100%;
-  max-width: 1200px;
-  padding: 0 0.25rem;
-}
-
-.sales-header h1 {
+.slg-sales-title {
   margin: 0;
-  font-size: 1.8rem;
+  font-family: var(--slg-display);
+  font-size: clamp(1.75rem, 7vw, 2.75rem);
+  font-weight: 400;
+  line-height: 1;
+  letter-spacing: 0.02em;
+  color: var(--slg-ink);
 }
 
-.sales-header p {
-  margin-top: 0.25rem;
-  color: #ccc;
+.slg-sales-tabs {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  max-width: 340px;
+  margin: 0 var(--slg-gutter-tight) 1.75rem;
+  border: 1px solid var(--slg-edge);
 }
 
-.sales-layout {
+.slg-sales-tab {
   display: flex;
-  margin-top: 0.5rem;
-}
-
-/* Sales list */
-.sales-list {
-  padding-right: 1rem;
-  border-right: 1px solid #333;
-  max-height: 75dvh;
-  overflow: auto;
-}
-
-.sales-list h2 {
-  margin-top: 0;
-}
-
-.sales-items {
-  margin-bottom: 0.75rem;
-}
-
-.sales-item {
-  display: flex;
-  gap: 0.75rem;
-  padding: 0.75rem;
-  background: #1b1b1b;
-  border: 1px solid #333;
-  margin-bottom: 0.5rem;
-  cursor: pointer;
   align-items: center;
+  justify-content: center;
+  min-height: 44px;
+  padding: 0 0.75rem;
+  font-family: var(--slg-body);
+  font-size: 0.8125rem;
+  font-weight: 500;
+  letter-spacing: 0.06em;
+  color: var(--slg-dim);
+  background: var(--slg-lift);
+  border: none;
+  cursor: pointer;
+  transition:
+    background 160ms ease,
+    color 160ms ease;
 }
 
-.sales-item-img-wrapper {
-  width: 60px;
-  height: 60px;
+.slg-sales-tab + .slg-sales-tab {
+  border-left: 1px solid var(--slg-edge);
+}
+
+.slg-sales-tab:hover {
+  color: var(--slg-ink);
+  background: var(--slg-lift-hover);
+}
+
+.slg-sales-tab--on,
+.slg-sales-tab--on:hover {
+  color: #000000;
+  background: var(--slg-ink);
+}
+
+/* ---------- stat strip ---------- */
+
+.slg-sales-stats {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1px;
+  margin-bottom: 1.75rem;
+  padding: 0 var(--slg-gutter-tight);
+}
+
+.slg-sales-stat {
+  display: grid;
+  gap: 0.3rem;
+  align-content: start;
+  padding: 0.85rem 0.9rem;
+  background: var(--slg-lift);
+  border: 1px solid var(--slg-edge-soft);
+}
+
+.slg-sales-stat-label {
+  font-size: 0.625rem;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  color: var(--slg-dim);
+  white-space: nowrap;
+}
+
+.slg-sales-stat-value {
+  font-family: var(--slg-display);
+  font-size: 1.5rem;
+  line-height: 1;
+  color: var(--slg-ink);
+  font-variant-numeric: tabular-nums;
+}
+
+.slg-sales-stat-value--owed {
+  color: var(--slg-flame);
+}
+
+.slg-sales-stat--bad {
+  background: rgba(229, 72, 77, 0.12);
+  border-color: rgba(229, 72, 77, 0.45);
+}
+
+.slg-sales-stat--bad .slg-sales-stat-label,
+.slg-sales-stat--bad .slg-sales-stat-value {
+  color: var(--slg-state-bad);
+}
+
+.slg-sales-stat--wait {
+  background: rgba(242, 201, 76, 0.12);
+  border-color: rgba(242, 201, 76, 0.45);
+}
+
+.slg-sales-stat--wait .slg-sales-stat-label,
+.slg-sales-stat--wait .slg-sales-stat-value {
+  color: var(--slg-state-wait);
+}
+
+/* ---------- body ---------- */
+
+.slg-sales-body {
+  display: grid;
+  gap: 2.5rem;
+  padding: 0 var(--slg-gutter-tight);
+}
+
+.slg-sales-main {
+  min-width: 0;
+}
+
+/* ---------- toolbar ---------- */
+
+.slg-sales-toolbar {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem 0.75rem;
+  padding-bottom: 0.85rem;
+  border-bottom: 1px solid var(--slg-edge);
+}
+
+.slg-sales-heading {
+  margin: 0;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  color: var(--slg-dim);
+}
+
+.slg-sales-count {
+  margin: 0 0 0 auto;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  color: var(--slg-dim);
+  font-variant-numeric: tabular-nums;
+}
+
+/* ---------- buttons ---------- */
+
+.slg-sales-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  min-height: 36px;
+  padding: 0 0.85rem;
+  font-family: var(--slg-body);
+  font-size: 0.75rem;
+  font-weight: 500;
+  letter-spacing: 0.06em;
+  text-decoration: none; /* the tracking link wears this too */
+  color: var(--slg-dim);
+  background: transparent;
+  border: 1px solid var(--slg-edge);
+  cursor: pointer;
+  transition:
+    background 160ms ease,
+    border-color 160ms ease,
+    color 160ms ease;
+}
+
+.slg-sales-button:hover:not(:disabled) {
+  color: var(--slg-ink);
+  border-color: var(--slg-dim);
+}
+
+.slg-sales-button:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+.slg-sales-button--primary {
+  color: #000000;
+  background: var(--slg-ink);
+  border-color: var(--slg-ink);
+}
+
+.slg-sales-button--primary:hover:not(:disabled) {
+  color: var(--slg-ink);
+  background: transparent;
+  border-color: var(--slg-ink);
+}
+.slg-field .slg-sales-button {
+  justify-self: start;
+}
+
+.slg-sales-button--wide {
+  min-height: 44px;
+  padding: 0 1.25rem;
+  font-size: 0.8125rem;
+}
+
+/* ---------- list ---------- */
+
+.slg-sale-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.slg-sale-empty {
+  margin: 0;
+  padding: 2.5rem 0;
+  max-width: 42ch;
+  font-size: 0.9375rem;
+  line-height: 1.6;
+  color: var(--slg-dim);
+}
+
+.slg-sale-row {
+  display: grid;
+  grid-template-columns: 52px minmax(0, 1fr);
+  grid-template-areas:
+    'thumb identity'
+    'thumb price'
+    'thumb stages';
+  align-items: center;
+  gap: 0.2rem 0.85rem;
+  width: 100%;
+  padding: 0.7rem 0.25rem;
+  font-family: var(--slg-body);
+  text-align: left;
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid var(--slg-edge-soft);
+  cursor: pointer;
+  transition: background 160ms ease;
+}
+
+.slg-sale-row:hover {
+  background: var(--slg-lift);
+}
+
+.slg-sale-row--on {
+  background: var(--slg-lift-hover);
+}
+
+.slg-sale-thumb {
+  grid-area: thumb;
+  align-self: start;
+  display: block;
+  width: 52px;
+  aspect-ratio: 1;
   overflow: hidden;
-  flex-shrink: 0;
-  border-radius: 4px;
+  background: var(--slg-lift);
 }
 
-.sales-item-img {
+.slg-sale-thumb img {
+  display: block;
   width: 100%;
   height: 100%;
   object-fit: cover;
 }
 
-.sales-item-info {
+.slg-sale-identity {
+  grid-area: identity;
+  display: grid;
+  gap: 0.1rem;
+  min-width: 0;
+}
+
+.slg-sale-title {
+  font-size: 0.875rem;
+  font-weight: 500;
+  line-height: 1.3;
+  color: var(--slg-ink);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.slg-sale-buyer {
+  font-size: 0.6875rem;
+  letter-spacing: 0.04em;
+  line-height: 1.4;
+  color: var(--slg-dim);
+  overflow-wrap: anywhere;
+}
+
+.slg-sale-price {
+  grid-area: price;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--slg-ink);
+  font-variant-numeric: tabular-nums;
+}
+
+/* ---------- the pipeline ---------- */
+
+.slg-stages {
+  grid-area: stages;
   display: flex;
-  flex-direction: column;
-  flex: 1;
-}
-
-.sales-detail-img {
-  width: 160px;
-  height: 160px;
-  object-fit: cover;
-  border: 1px solid #333;
-  margin-bottom: 1rem;
-}
-
-.sales-item.selected {
-  border-color: #2f00ff83;
-  background-color: #333;
-}
-
-.sales-item-header {
-  font-weight: bold;
-  margin-bottom: 0.25rem;
-}
-
-.sales-item-meta {
-  font-size: 0.8rem;
-  color: #bbb;
-  display: flex;
-  justify-content: space-between;
-}
-
-.sales-post-title {
-  font-size: 1rem;
-}
-
-/* Right panel */
-.sales-panel {
-  width: 65%;
-  padding-left: 1.5rem;
-}
-
-.no-sale-selected {
-  padding: 1rem;
-  color: #aaa;
-}
-
-.sales-detail h2 {
-  margin-top: 0;
-}
-
-.sales-detail-row {
-  display: flex;
-  margin: 0 0 0.25rem 0;
+  align-items: center;
   gap: 0.5rem;
 }
 
-.sales-detail-row label {
-  width: 100px;
-  color: #ccc;
+.slg-stage-track {
+  display: flex;
+  gap: 3px;
+  flex: 0 0 auto;
 }
 
-.tracking-input {
-  width: 250px;
-  padding: 0.3rem;
-  background: #111;
-  border: 1px solid #555;
-  color: #fff;
+.slg-stage-bar {
+  display: block;
+  width: 15px;
+  height: 3px;
+  background: var(--slg-edge);
 }
 
-.save-tracking-button {
-  background: green;
-  color: #000;
-  border: none;
-  padding: 0.5rem 1rem;
-  cursor: pointer;
-  margin-top: 1rem;
+.slg-stage-bar--done {
+  background: var(--slg-ink);
 }
 
-.add-sale-button {
-  background: green;
-  color: #000;
-  border: none;
-  padding: 0.4rem 0.9rem;
-  cursor: pointer;
-  margin-left: auto;
-  font-size: 0.9rem;
+.slg-stage-status {
+  font-size: 0.625rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  color: var(--slg-dim);
 }
 
-.sales-header {
+.slg-stages--bad .slg-stage-bar--done,
+.slg-stages--bad .slg-stage-step--done .slg-stage-bar {
+  background: var(--slg-state-bad);
+}
+
+.slg-stages--wait .slg-stage-bar--done,
+.slg-stages--wait .slg-stage-step--done .slg-stage-bar {
+  background: var(--slg-state-wait);
+}
+
+.slg-stages--good .slg-stage-bar--done,
+.slg-stages--good .slg-stage-step--done .slg-stage-bar {
+  background: var(--slg-state-good);
+}
+
+.slg-stages--bad .slg-stage-status,
+.slg-stages--bad .slg-stage-step--done .slg-stage-name {
+  color: var(--slg-state-bad);
+}
+
+.slg-stages--wait .slg-stage-status,
+.slg-stages--wait .slg-stage-step--done .slg-stage-name {
+  color: var(--slg-state-wait);
+}
+
+.slg-stages--good .slg-stage-status,
+.slg-stages--good .slg-stage-step--done .slg-stage-name {
+  color: var(--slg-state-good);
+}
+
+.slg-stages--detail {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.slg-stage-step {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.slg-stage-step .slg-stage-bar {
+  width: 100%;
+}
+
+.slg-stage-step--done .slg-stage-bar {
+  background: var(--slg-ink);
+}
+
+.slg-stage-name {
+  font-size: 0.625rem;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  color: var(--slg-dim);
+}
+
+.slg-stage-step--done .slg-stage-name {
+  color: var(--slg-ink);
+}
+
+/* ---------- detail rail ---------- */
+
+.slg-sales-rail {
+  min-width: 0;
+}
+
+.slg-sale-panel {
+  background: var(--slg-lift);
+  border: 1px solid var(--slg-edge-soft);
+}
+
+.slg-sale-panel-head {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 0.75rem;
+  min-height: 48px;
+  padding: 0 0.9rem;
+  border-bottom: 1px solid var(--slg-edge-soft);
 }
 
-.cancel-button {
-  background: #444;
-  color: #fff;
-  border: none;
-  padding: 0.4rem 0.9rem;
-  cursor: pointer;
-  margin-left: 0.5rem;
+.slg-sale-panel-title {
+  margin: 0;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  color: var(--slg-ink);
 }
 
-.sales-paid-status {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  gap: 1rem;
-  margin: 1rem 0;
+.slg-sale-panel-body {
+  display: grid;
+  gap: 1.25rem;
+  padding: 1.1rem 0.9rem 1.25rem;
 }
 
-.sales-paid-status-indicator {
-  padding: 0.25rem 0.5rem;
-  border-radius: 6px;
+.slg-sale-placeholder {
+  margin: 0;
+  padding: 2rem 0.9rem;
+  max-width: 34ch;
+  font-size: 0.875rem;
+  line-height: 1.6;
+  color: var(--slg-dim);
+}
+
+/* ---------- detail: the piece ---------- */
+
+.slg-sale-piece {
+  display: grid;
+  grid-template-columns: 96px minmax(0, 1fr);
+  align-items: start;
+  gap: 0.9rem;
+}
+
+.slg-sale-piece-image {
+  display: block;
+  width: 96px;
+  aspect-ratio: 1;
+  object-fit: cover;
+  background: var(--slg-void);
+}
+
+.slg-sale-piece-meta {
+  display: grid;
+  gap: 0.25rem;
+  min-width: 0;
+}
+
+.slg-sale-piece-title {
+  margin: 0;
+  font-family: var(--slg-display);
+  font-size: 1.25rem;
+  font-weight: 400;
+  line-height: 1.15;
+  color: var(--slg-ink);
+}
+
+.slg-sale-piece-price {
+  font-family: var(--slg-display);
   font-size: 1.5rem;
-  background-color: #111;
-  border: 1px solid #444;
-  color: black;
+  line-height: 1;
+  color: var(--slg-ink);
+  font-variant-numeric: tabular-nums;
 }
 
-.sale-paid-toggle-button,
-.save-tracking-button,
-.add-sale-button {
-  transition: background 0.15s;
-  max-width: 150px;
-  padding: 4px 8px;
-  background: none;
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
-  color: white;
-  font-size: 0.8rem;
-  width: 40%;
-  border-width: 1px;
-  border-style: solid;
+/* ---------- detail: facts ---------- */
+
+.slg-sale-facts {
+  display: grid;
+  gap: 0.75rem;
+  margin: 0;
 }
 
-.sale-paid-toggle-button:hover,
-.save-tracking-button:hover,
-.add-sale-button:hover {
-  background-color: darkgreen;
+.slg-sale-fact {
+  display: grid;
+  gap: 0.2rem;
 }
 
-.sale-paid-toggle-button:active,
-.save-tracking-button:active,
-.add-sale-button:active {
-  background-color: rgb(0, 47, 0);
-  border-color: #555;
+.slg-sale-fact-label {
+  font-size: 0.625rem;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  color: var(--slg-dim);
 }
 
-/* 
+.slg-sale-fact-value {
+  margin: 0;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  color: var(--slg-ink);
+  overflow-wrap: anywhere;
+}
 
-/* User search */
-.user-search-results {
+.slg-sale-fact-value--missing {
+  color: var(--slg-alert);
+}
+
+.slg-sale-address {
+  display: grid;
+  gap: 0.5rem;
+  justify-items: start;
+}
+
+.slg-sale-address-lines {
+  font-size: 0.875rem;
+  line-height: 1.5;
+  color: var(--slg-ink);
+}
+
+/* ---------- detail: tracking ---------- */
+
+.slg-sale-tracking-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.5rem 0.6rem;
+  text-decoration: none;
+  background: var(--slg-void);
+  border: 1px solid var(--slg-edge);
+  transition: border-color 160ms ease;
+}
+
+.slg-sale-tracking-link:hover {
+  border-color: var(--slg-dim);
+}
+
+.slg-sale-tracking-mark {
+  display: block;
+  width: 40px;
+  height: 40px;
+  object-fit: contain;
+  flex: 0 0 auto;
+}
+
+.slg-sale-tracking-text {
+  display: grid;
+  gap: 0.15rem;
+  min-width: 0;
+}
+
+.slg-sale-tracking-caption {
+  font-size: 0.625rem;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  color: var(--slg-dim);
+}
+
+.slg-sale-tracking-number {
+  font-size: 0.875rem;
+  color: var(--slg-ink);
+  font-variant-numeric: tabular-nums;
+  overflow-wrap: anywhere;
+}
+
+/* ---------- detail: actions ---------- */
+
+.slg-sale-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  padding-top: 0.25rem;
+}
+
+/* ---------- customer search ---------- */
+
+.slg-user-search {
+  position: relative;
+}
+
+.slg-user-results {
   position: absolute;
-  top: 34px;
+  top: calc(100% + 2px);
   left: 0;
-  width: 320px;
+  right: 0;
   max-height: 280px;
   overflow-y: auto;
-  background: #0f0f0f;
-  border: 1px solid #333;
-  border-radius: 4px;
+  background: var(--slg-void);
+  border: 1px solid var(--slg-edge);
   z-index: 20;
 }
 
-.user-result-item {
+.slg-user-result {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.4rem 0.5rem;
+  gap: 0.6rem;
+  width: 100%;
+  padding: 0.5rem 0.6rem;
+  font-family: var(--slg-body);
+  text-align: left;
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid var(--slg-edge-soft);
   cursor: pointer;
-  border-bottom: 1px solid #222;
+  transition: background 160ms ease;
 }
 
-.user-result-item:hover {
-  background: #1f1f1f;
+.slg-user-result:hover {
+  background: var(--slg-lift-hover);
 }
 
-.user-result-item.empty {
-  color: #aaa;
-  cursor: default;
+.slg-user-results-empty {
+  padding: 0.75rem 0.6rem;
+  font-size: 0.8125rem;
+  color: var(--slg-dim);
 }
 
-.user-avatar {
-  width: 28px;
-  height: 28px;
-  border-radius: 50%;
+.slg-user-identity {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  min-width: 0;
+}
+
+.slg-user-avatar {
+  width: 30px;
+  height: 30px;
   object-fit: cover;
+  border-radius: 50%;
+  flex: 0 0 auto;
 }
 
-.user-avatar-fallback {
-  width: 28px;
-  height: 28px;
-  border-radius: 50%;
+.slg-user-avatar--fallback {
   display: flex;
   align-items: center;
   justify-content: center;
-  background: #333;
-  color: #eee;
-  font-weight: bold;
-}
-
-.user-meta {
-  display: flex;
-  flex-direction: column;
-}
-
-.user-name {
+  font-size: 0.8125rem;
   font-weight: 600;
+  color: var(--slg-ink);
+  background: var(--slg-lift-hover);
+  border: 1px solid var(--slg-edge);
 }
 
-.user-email {
-  font-size: 0.8rem;
-  color: #bbb;
+.slg-user-meta {
+  display: grid;
+  gap: 0.1rem;
+  min-width: 0;
 }
 
-.selected-user-card {
-  border: 1px solid #333;
-  background: #141414;
-  padding: 0.6rem;
-  border-radius: 6px;
-  margin: 0.25rem 0 0.75rem 100px;
+.slg-user-name {
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--slg-ink);
 }
 
-.selected-user-header {
+.slg-user-email {
+  font-size: 0.6875rem;
+  color: var(--slg-dim);
+  overflow-wrap: anywhere;
+}
+
+.slg-user-card {
+  display: grid;
+  gap: 0.75rem;
+  padding: 0.75rem;
+  background: var(--slg-void);
+  border: 1px solid var(--slg-edge);
+}
+
+/* ---------- modals ---------- */
+
+.slg-modal-scrim {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  justify-content: center;
+  padding: 1rem;
+  background: rgba(0, 0, 0, 0.75);
 }
 
-.address-missing {
-  color: #ff6b6b;
-}
-
-.selected-user-address-actions {
-  display: flex;
-  justify-content: flex-end;
-  margin-bottom: 0.25rem;
-}
-
-.copy-address-button {
-  position: absolute;
-  background: #222;
-  color: #fff;
-  border: 1px solid #444;
-  font-size: 0.65rem;
-  padding: 2px 6px;
-  border-radius: 4px;
-  cursor: pointer;
-  height: 2rem;
-  width: 5rem;
-}
-
-.copy-address-button:hover:not(:disabled) {
-  background: #333;
-}
-
-.copy-address-button:disabled {
-  opacity: 0.4;
-  cursor: not-allowed;
-}
-
-.search-email-button,
-.search-post-button {
-  background: #222;
-  color: #fff;
-  border: 1px solid #444;
-  font-size: 0.65rem;
-  padding: 2px 8px;
-  border-radius: 4px;
-  cursor: pointer;
-  height: 2rem;
-  width: 5rem;
-}
-
-.search-email-button,
-.search-post-button:hover {
-  background: #333;
-}
-.search-email-button-mobile,
-.search-post-button-mobile {
-  display: none;
-}
-
-.admin-sales-tabs {
-  display: flex;
+.slg-modal {
+  display: grid;
   gap: 1rem;
-  margin-bottom: 1rem;
   width: 100%;
+  max-width: 420px;
+  max-height: 85vh;
+  overflow-y: auto;
+  padding: 1.25rem;
+  background: var(--slg-lift);
+  border: 1px solid var(--slg-edge);
 }
 
-.admin-sales-tabs button {
-  padding: 0.5rem 1rem;
-  background: #222;
-  border: 1px solid #444;
-  cursor: pointer;
-  color: #ddd;
+.slg-modal--wide {
+  max-width: 760px;
 }
 
-.admin-sales-tabs button.active {
-  background: #333;
-  border-color: #999;
-  color: #fff;
+.slg-modal-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
 }
 
-.admin-sales-tab-content {
-  width: 100%;
-}
-
-.sales-header h3 {
+.slg-modal-title {
   margin: 0;
-  padding-bottom: 0.25rem;
-  font-weight: 600;
-  color: #fff;
-  text-align: left;
+  font-family: var(--slg-display);
+  font-size: 1.375rem;
+  font-weight: 400;
+  line-height: 1;
+  color: var(--slg-ink);
 }
 
-/*
+.slg-modal-close {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  padding: 0;
+  font-family: var(--slg-body);
+  font-size: 1rem;
+  line-height: 1;
+  color: var(--slg-dim);
+  background: transparent;
+  border: 1px solid var(--slg-edge);
+  cursor: pointer;
+  transition:
+    color 160ms ease,
+    border-color 160ms ease;
+}
 
-^================== Responsive begin ======================= 
+.slg-modal-close:hover {
+  color: var(--slg-ink);
+  border-color: var(--slg-dim);
+}
 
-*/
+.slg-modal-actions {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: flex-end;
+}
 
-@media (max-width: 768px) {
-  .search-email-button,
-  .search-post-button {
-    display: none;
+/* ---------- post finder ---------- */
+
+.slg-post-picker {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 1px;
+}
+
+.slg-post-option {
+  display: grid;
+  grid-template-columns: 64px minmax(0, 1fr);
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.5rem;
+  font-family: var(--slg-body);
+  text-align: left;
+  background: transparent;
+  border: 1px solid var(--slg-edge-soft);
+  cursor: pointer;
+  transition: background 160ms ease;
+}
+
+.slg-post-option:hover {
+  background: var(--slg-lift-hover);
+}
+
+.slg-post-option img {
+  display: block;
+  width: 64px;
+  aspect-ratio: 1;
+  object-fit: cover;
+  background: var(--slg-void);
+}
+
+.slg-post-option-meta {
+  display: grid;
+  gap: 0.15rem;
+  min-width: 0;
+}
+
+.slg-post-option-title {
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--slg-ink);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.slg-post-option-sub {
+  font-size: 0.6875rem;
+  color: var(--slg-dim);
+  font-variant-numeric: tabular-nums;
+}
+
+/* ---------- shared ---------- */
+
+.slg-sales-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
+.slg-sales button:focus-visible,
+.slg-sales a:focus-visible,
+.slg-sales input:focus-visible,
+.slg-modal-scrim button:focus-visible,
+.slg-modal-scrim input:focus-visible {
+  outline: 2px solid var(--slg-flame);
+  outline-offset: 2px;
+}
+
+/* ---------- wider screens ---------- */
+
+@media (min-width: 700px) {
+  .slg-sales-head,
+  .slg-sales-stats,
+  .slg-sales-body {
+    padding-left: var(--slg-gutter);
+    padding-right: var(--slg-gutter);
   }
 
-  .mobile-button-wrapper {
-    display: flex;
-    justify-content: flex-end;
+  .slg-sales-tabs {
+    margin-left: var(--slg-gutter);
+    margin-right: var(--slg-gutter);
+  }
+
+  .slg-sales-stats {
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  }
+
+  .slg-sale-row {
+    grid-template-columns: 64px minmax(0, 1fr) 90px 150px;
+    grid-template-areas: 'thumb identity price stages';
     gap: 1rem;
-    margin-top: 0.5rem;
+    padding: 0.6rem 0.25rem;
   }
 
-  .search-email-button-mobile,
-  .search-post-button-mobile {
-    display: unset;
-    background: #222;
-    color: #fff;
-    border: 1px solid #444;
-    font-size: 0.65rem;
-    padding: 2px 8px;
-    border-radius: 4px;
-    cursor: pointer;
-    height: 2rem;
+  .slg-sale-thumb {
+    width: 64px;
+    align-self: center;
   }
 
-  .search-email-button-mobile:hover,
-  .search-post-button-mobile:hover {
-    background: #333;
+  .slg-sale-title {
+    -webkit-line-clamp: 1;
+  }
+}
+
+@media (min-width: 1100px) {
+  .slg-sales-body {
+    grid-template-columns: minmax(0, 1fr) 400px;
+    gap: var(--slg-gutter);
+    align-items: start;
   }
 
-  .sales-layout {
-    flex-direction: column;
+  .slg-sales-rail {
+    position: sticky;
+    top: calc(var(--slg-header-height) + 1.5rem);
+  }
+}
+
+@media (min-width: 1100px) {
+  .slg-sales-body--full {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+@media (min-width: 1800px) {
+  .slg-sales-body {
+    grid-template-columns: minmax(0, 1fr) 460px;
   }
 
-  .sales-list {
-    width: 100%;
-    border-right: none;
-    padding-right: 0;
-    margin-bottom: 1rem;
+  .slg-sales-body--full {
+    grid-template-columns: minmax(0, 1fr);
   }
+}
 
-  .sales-panel {
-    width: 100%;
-    padding-left: 0;
-  }
-
-  .sales-detail-img {
-    width: 120px;
-    height: 120px;
-  }
-
-  .sales-item-img-wrapper {
-    width: 50px;
-    height: 50px;
-  }
-  .admin-sales-wrapper {
-    width: 100%;
-  }
-
-  .user-search-results {
-    width: 260px;
-  }
-  .selected-user-card {
-    margin-left: 0;
+@media (prefers-reduced-motion: reduce) {
+  .slg-sales *,
+  .slg-modal-scrim * {
+    transition-duration: 1ms;
   }
 }

--- a/src/components/Admin/AdminSales/AdminSales.js
+++ b/src/components/Admin/AdminSales/AdminSales.js
@@ -3,32 +3,52 @@ import './AdminSales.css';
 import GallerySalesPanel from './GallerySalesPanel.js';
 import AuctionResultsPanel from './AuctionResultsPanel.js';
 
-export default function AdminSales() {
+const TABS = [
+  { id: 'gallery', label: 'Gallery' },
+  { id: 'auctions', label: 'Auction' },
+];
+
+const AdminSales = () => {
   const [activeTab, setActiveTab] = useState('gallery');
 
   return (
-    <div className="admin-sales-wrapper">
-      <h2 style={{ margin: '0.25rem', textAlign: 'center' }}>Sales</h2>
-      <div className="admin-sales-tabs">
-        <button
-          className={activeTab === 'gallery' ? 'active' : ''}
-          onClick={() => setActiveTab('gallery')}
-        >
-          Gallery
-        </button>
-
-        <button
-          className={activeTab === 'auctions' ? 'active' : ''}
-          onClick={() => setActiveTab('auctions')}
-        >
-          Auction
-        </button>
+    <div className="slg-sales">
+      <div className="slg-sales-head">
+        <p className="slg-eyebrow">Admin</p>
+        <h1 className="slg-sales-title">Sales</h1>
       </div>
 
-      <div className="admin-sales-tab-content">
-        {activeTab === 'gallery' && <GallerySalesPanel />}
-        {activeTab === 'auctions' && <AuctionResultsPanel />}
+      <div className="slg-sales-tabs" role="tablist" aria-label="Sales source">
+        {TABS.map((tab) => (
+          <button
+            key={tab.id}
+            type="button"
+            role="tab"
+            id={`slg-sales-tab-${tab.id}`}
+            aria-selected={activeTab === tab.id}
+            aria-controls={`slg-sales-view-${tab.id}`}
+            className={`slg-sales-tab${activeTab === tab.id ? ' slg-sales-tab--on' : ''}`}
+            onClick={() => setActiveTab(tab.id)}
+          >
+            {tab.label}
+          </button>
+        ))}
       </div>
+
+      {TABS.map((tab) =>
+        activeTab === tab.id ? (
+          <div
+            key={tab.id}
+            role="tabpanel"
+            id={`slg-sales-view-${tab.id}`}
+            aria-labelledby={`slg-sales-tab-${tab.id}`}
+          >
+            {tab.id === 'gallery' ? <GallerySalesPanel /> : <AuctionResultsPanel />}
+          </div>
+        ) : null
+      )}
     </div>
   );
-}
+};
+
+export default AdminSales;

--- a/src/components/Admin/AdminSales/AuctionResultsPanel.css
+++ b/src/components/Admin/AdminSales/AuctionResultsPanel.css
@@ -1,101 +1,89 @@
-.auction-results-panel {
-  width: 100%;
-  background: rgba(0, 0, 0, 0.8);
-  border-right: 1px solid rgba(255, 255, 255, 0.1);
-  overflow-y: auto;
-  color: white;
+/* Auction results, admin side.
+ *
+ * The same list as the gallery tab, with one difference that changes the
+ * shape: a result carries its own controls. A row can't be a single
+ * button and also contain buttons, so it splits in two — the piece is
+ * the link to the auction, and the state block beside it holds the
+ * pipeline and the controls that move it.
+ *
+ * Everything else — thumbnail, title, price, stages — is the shared row
+ * vocabulary in AdminSales.css. Only what is genuinely specific to a
+ * result lives here.
+ */
+
+.slg-auction-row {
+  display: grid;
+  gap: 0.75rem;
+  padding: 0.7rem 0;
+  border-bottom: 1px solid var(--slg-edge-soft);
 }
 
-.auction-results-panel h3 {
-  margin: 0 0 1rem 0;
-  padding-bottom: 0.25rem;
-  font-weight: 600;
-  color: #fff;
+.slg-auction-piece {
+  display: grid;
+  grid-template-columns: 52px minmax(0, 1fr) auto;
+  grid-template-areas:
+    'thumb identity price'
+    'thumb identity price';
+  align-items: center;
+  gap: 0.2rem 0.85rem;
+  width: 100%;
+  padding: 0 0.25rem;
+  font-family: var(--slg-body);
   text-align: left;
-}
-
-.auction-results-list {
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-}
-
-.auction-result-item {
-  display: flex;
-  align-items: flex-start;
-  gap: 0.75rem;
-  padding: 0.6rem;
-  border-radius: 10px;
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  background: rgba(255, 255, 255, 0.05);
-  transition:
-    box-shadow 0.2s ease,
-    border-color 0.2s ease;
-  min-height: 85px;
-}
-
-.auction-result-thumb {
-  width: 60px;
-  height: 60px;
-  object-fit: cover;
-  border-radius: 8px;
-  flex-shrink: 0;
-  border: 1px solid rgba(255, 255, 255, 0.15);
+  background: transparent;
+  border: none;
   cursor: pointer;
+  transition: background 160ms ease;
 }
 
-.auction-result-thumb.placeholder {
-  background: rgba(255, 255, 255, 0.1);
+.slg-auction-piece:hover {
+  background: var(--slg-lift);
 }
 
-.auction-result-info {
+.slg-auction-state {
   display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  flex: 1;
-  min-width: 0;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem 0.85rem;
+  padding: 0 0.25rem;
 }
 
-.auction-result-info h4 {
-  font-size: 1rem;
-  margin: 0 0 0.25rem 0;
-  color: #fff;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  overflow: hidden;
+/* An open auction has no pipeline yet — nothing is owed and nothing can
+   ship — so it says so in the flame the rest of the site reserves for
+   live bidding, and the three segments stay off until it closes. */
+.slg-auction-live {
+  font-size: 0.625rem;
   font-weight: 600;
-  line-height: 1.2;
+  letter-spacing: 0.12em;
+  color: var(--slg-flame);
 }
 
-.auction-result-info p {
-  margin: 0;
-  font-size: 0.88rem;
-  color: rgba(255, 255, 255, 0.85);
+.slg-auction-actions {
   display: flex;
-  justify-content: space-between;
-  width: 100%;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin-left: auto;
 }
 
-.closed {
-  border-color: rgba(0, 255, 0, 0.25);
+@media (min-width: 700px) {
+  .slg-auction-piece {
+    grid-template-columns: 64px minmax(0, 1fr) 110px;
+    grid-template-areas: 'thumb identity price';
+    gap: 1rem;
+  }
 }
 
-.active-auction {
-  border-color: rgba(255, 255, 255, 0.549);
-}
+/* Wide enough for the result and its controls to share a line, which is
+   how the list reads on a desktop: a column of pieces and a column of
+   things to do about them. */
+@media (min-width: 1100px) {
+  .slg-auction-row {
+    grid-template-columns: minmax(0, 1fr) minmax(320px, auto);
+    align-items: center;
+    gap: 1rem;
+  }
 
-.high-bid-line {
-  color: #9f9;
-  font-weight: 500;
-  margin-top: 0.25rem;
-  border-top: 1px solid rgba(255, 255, 255, 0.1);
-  padding-top: 0.25rem;
-}
-
-@media (min-width: 1024px) {
-  .auction-results-panel {
-    width: 100%;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.1);
-    padding: 0.5rem;
+  .slg-auction-state {
+    justify-content: flex-end;
   }
 }

--- a/src/components/Admin/AdminSales/AuctionResultsPanel.js
+++ b/src/components/Admin/AdminSales/AuctionResultsPanel.js
@@ -5,6 +5,7 @@ import {
   markAuctionPaid,
   updateAuctionTracking,
 } from '../../../services/fetch-auctions.js';
+import './AdminSales.css';
 import './AuctionResultsPanel.css';
 import { toast } from 'react-toastify';
 import websocketService from '../../../services/websocket.js';
@@ -12,8 +13,12 @@ import { useAuctionEventsStore } from '../../../stores/auctionEventsStore.js';
 import { useNavigate } from 'react-router-dom';
 import Loading from '../../Loading/Loading.js';
 import { getAllUsers } from '../../../services/fetch-utils.js';
+import SaleStages from './SaleStages.js';
+import { countCompletedStages, hasRealTracking } from './saleStatus.js';
 
-export default function AuctionResultsPanel() {
+const formatMoney = (amount) => `$${Number(amount || 0).toLocaleString()}`;
+
+const AuctionResultsPanel = () => {
   const [auctions, setAuctions] = useState([]);
   const [loading, setLoading] = useState(true);
 
@@ -215,7 +220,6 @@ export default function AuctionResultsPanel() {
           })
         );
 
-        // setAuctions(withResults);
         setAuctions(withResults.filter((a) => a.topBid));
       } catch (e) {
         console.error('Error loading auctions:', e);
@@ -282,307 +286,236 @@ export default function AuctionResultsPanel() {
     };
   }, []);
 
+  const handleTogglePaid = async (auctionId, currentPaid) => {
+    try {
+      await markAuctionPaid(auctionId, !currentPaid);
+
+      setAuctions((prev) =>
+        prev.map((x) => (x.id === auctionId ? { ...x, isPaid: !currentPaid } : x))
+      );
+    } catch (e) {
+      console.error('Error marking auction paid');
+      toast.error(`${e.message}` || 'Error marking auction paid', {
+        theme: 'colored',
+        draggable: true,
+        draggablePercent: 60,
+        toastId: 'auction-list-1',
+        autoClose: false,
+      });
+    }
+  };
+
   if (loading) {
-    return (
-      <aside className="auction-results-panel">
-        <Loading />
-      </aside>
-    );
+    return <Loading />;
   }
 
-  // Calculate total owed to admin: auctions with a winner, not paid
   const totalOwed = auctions
     .filter((auction) => auction.winner && !auction.isPaid)
     .reduce((sum, auction) => sum + (auction.topBid?.bidAmount || 0), 0);
 
+  const awaitingPayment = auctions.filter((auction) => !auction.isPaid).length;
+  const readyToShip = auctions.filter(
+    (auction) => auction.isPaid && !hasRealTracking(auction.trackingNumber)
+  ).length;
+
+  const statTiles = [
+    { label: 'Results', value: auctions.length },
+    { label: 'Unpaid', value: awaitingPayment, tone: awaitingPayment > 0 ? 'bad' : null },
+    { label: 'To ship', value: readyToShip, tone: readyToShip > 0 ? 'wait' : null },
+    { label: 'Owed', value: formatMoney(totalOwed), isOwed: true },
+  ];
+
   return (
-    <aside className="auction-results-panel">
-      <div style={{ display: 'block' }}>
-        <h3 style={{ margin: 0, padding: 0 }}>Auctions</h3>
-        <div style={{ marginBottom: '.25rem' }}>
-          <span style={{ fontSize: '1.25rem' }}>Unpaid Total:</span>
-          <span style={{ color: '#9f9' }}> ${totalOwed.toLocaleString()}</span>
-        </div>
-        <div style={{ marginBottom: '.25rem' }}>
-          <span style={{ fontSize: '1.25rem', border: '2x solid yellow', padding: '0 4px' }}>
-            {auctions.filter((auction) => !auction.trackingNumber).length > 0
-              ? 'Need to ship! '
-              : ''}
-          </span>
-          <span
-            style={{
-              color:
-                auctions.filter((auction) => !auction.trackingNumber).length > 0
-                  ? 'yellow'
-                  : '#9f9',
-            }}
-          >
-            {auctions.filter((auction) => !auction.trackingNumber).length > 0
-              ? 'SHIPPING REQUIRED ' && auctions.filter((auction) => !auction.trackingNumber).length
-              : 'All clear '}
-          </span>
-        </div>
-      </div>
-      <div className="auction-results-list">
-        {auctions.map((a) => {
-          const isClosed = !a.isActive;
-          const winnerName = a.winner
-            ? `${a.winner.firstName || ''} ${a.winner.lastName || ''}`.trim()
-            : '—';
-          const finalBid = a.topBid?.bidAmount ?? a.currentBid ?? a.startPrice;
-          const image = a.imageUrls?.[0];
-          const highBid = a.topBid ? a.topBid.bidAmount : 0;
-
-          const handleTogglePaid = async (auctionId, currentPaid) => {
-            try {
-              await markAuctionPaid(auctionId, !currentPaid);
-
-              setAuctions((prev) =>
-                prev.map((x) => (x.id === auctionId ? { ...x, isPaid: !currentPaid } : x))
-              );
-            } catch (e) {
-              console.error('Error marking auction paid');
-              toast.error(`${e.message}` || 'Error marking auction paid', {
-                theme: 'colored',
-                draggable: true,
-                draggablePercent: 60,
-                toastId: 'auction-list-1',
-                autoClose: false,
-              });
-            }
-          };
-          const navAuction = (auctionId) => {
-            navigate(`/auctions/${auctionId}`);
-          };
-          return (
-            <div
-              key={a.id}
-              className={`auction-result-item ${isClosed ? 'closed' : 'active-auction'}`}
-              style={{
-                border: a.trackingNumber ? '' : '2px solid yellow',
-                backgroundColor: a.trackingNumber ? '' : '#222',
-              }}
-            >
-              {/* Remove long ternary for image rendering */}
-              {image && (
-                <div style={{ display: 'grid' }}>
-                  <img
-                    src={image}
-                    alt={a.title}
-                    onClick={() => {
-                      navAuction(a.id);
-                    }}
-                    className="auction-result-thumb"
-                  />
-                  {isClosed && a.trackingNumber && (
-                    <a
-                      href={`https://tools.usps.com/go/TrackConfirmAction?tLabels=${encodeURIComponent(
-                        a.trackingNumber
-                      )}`}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      aria-label={`View tracking for ${a.title}`}
-                    >
-                      <img
-                        alt="USPS"
-                        className="auction-result-thumb"
-                        style={{ width: '50px', height: '50px', margin: '.5rem 0 0 .25rem' }}
-                        src="../../../usps.png"
-                      />
-                    </a>
-                  )}
-                </div>
-              )}
-              {!image && <div className="auction-result-thumb placeholder" />}
-
-              <div className="auction-result-info">
-                {isClosed && (
-                  <div style={{ display: 'flex', justifyContent: 'space-between' }}>
-                    <button
-                      onClick={() => handleTogglePaid(a.id, a.isPaid)}
-                      style={{
-                        padding: '4px 8px',
-                        background: a.isPaid ? '#2a2' : '#a22',
-                        border: 'none',
-                        borderRadius: '4px',
-                        cursor: 'pointer',
-                        color: 'white',
-                        fontSize: '0.8rem',
-                        width: '40%',
-                      }}
-                    >
-                      {a.isPaid ? 'Paid' : 'Mark Paid'}
-                    </button>
-                    {a.isPaid && (
-                      <button
-                        onClick={() => openTrackingModal(a.id, a.trackingNumber)}
-                        style={{
-                          padding: '4px 8px',
-                          background: '#464646ff',
-                          border: 'none',
-                          borderRadius: '4px',
-                          cursor: 'pointer',
-                          color: 'white',
-                          fontSize: '0.8rem',
-                          width: '40%',
-                        }}
-                      >
-                        {a.trackingNumber ? `...${a.trackingNumber.slice(-4)}` : 'Tracking'}
-                      </button>
-                    )}
-                  </div>
-                )}
-
-                <h4 title={a.title}>{a.title}</h4>
-
-                <p>
-                  <span>Status:</span> {isClosed ? 'Closed' : 'Active'}
-                </p>
-
-                <p>
-                  <span>{isClosed ? 'Winner:' : 'High Bidder:'}</span>{' '}
-                  {winnerName.length < 30
-                    ? winnerName
-                    : winnerName.substring(0, 20) + '...' || 'No bids'}
-                </p>
-
-                {isClosed && (
-                  <p>
-                    <span>Owes:</span> {a.topBid ? `$${finalBid.toLocaleString()}` : '—'}
-                  </p>
-                )}
-
-                <p>
-                  <span>High Bid:</span> {highBid ? `$${highBid.toLocaleString()}` : 'No bids'}
-                </p>
-              </div>
-            </div>
-          );
-        })}
-      </div>
-      {showTrackingModal && (
-        <div
-          style={{
-            position: 'fixed',
-            top: 0,
-            left: 0,
-            width: '100vw',
-            height: '100vh',
-            background: 'rgba(0,0,0,0.6)',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            zIndex: 9999,
-          }}
-        >
+    <>
+      <div className="slg-sales-stats">
+        {statTiles.map((tile) => (
           <div
-            style={{
-              background: '#222',
-              padding: '20px',
-              borderRadius: '8px',
-              width: '320px',
-              display: 'flex',
-              flexDirection: 'column',
-              gap: '12px',
-            }}
+            key={tile.label}
+            className={`slg-sales-stat${tile.tone ? ` slg-sales-stat--${tile.tone}` : ''}`}
           >
-            <h4 style={{ margin: 0 }}>Enter Tracking</h4>
-
-            <div
-              style={{
-                background: '#1a1a1a',
-                border: '1px solid #333',
-                borderRadius: '6px',
-                padding: '10px',
-                display: 'flex',
-                flexDirection: 'column',
-                gap: '8px',
-              }}
+            <span className="slg-sales-stat-label">{tile.label}</span>
+            <span
+              className={`slg-sales-stat-value${tile.isOwed ? ' slg-sales-stat-value--owed' : ''}`}
             >
-              <div
-                style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}
-              >
-                <strong style={{ fontSize: '0.9rem' }}>Shipping Address</strong>
-                <button
-                  onClick={copyAddressText}
-                  disabled={!address}
-                  style={{
-                    padding: '4px 8px',
-                    background: address ? '#444' : '#333',
-                    border: 'none',
-                    borderRadius: '4px',
-                    cursor: address ? 'pointer' : 'not-allowed',
-                    color: 'white',
-                    fontSize: '0.8rem',
-                  }}
-                >
-                  Copy
-                </button>
-              </div>
+              {tile.value}
+            </span>
+          </div>
+        ))}
+      </div>
 
+      <div className="slg-sales-body slg-sales-body--full">
+        <main className="slg-sales-main">
+          <div className="slg-sales-toolbar">
+            <h2 className="slg-sales-heading">Auction results</h2>
+            <p className="slg-sales-count">{auctions.length}</p>
+          </div>
+
+          {auctions.length === 0 ? (
+            <p className="slg-sale-empty">
+              No auctions have taken a bid yet. Results appear here once bidding starts.
+            </p>
+          ) : (
+            <ul className="slg-sale-list">
+              {auctions.map((auction) => {
+                const isClosed = !auction.isActive;
+                const winnerName = auction.winner
+                  ? `${auction.winner.firstName || ''} ${auction.winner.lastName || ''}`.trim()
+                  : '';
+                const highBid = auction.topBid ? auction.topBid.bidAmount : 0;
+                const image = auction.imageUrls?.[0];
+                const completedStages = countCompletedStages({
+                  isPaid: auction.isPaid,
+                  trackingNumber: auction.trackingNumber,
+                });
+
+                return (
+                  <li key={auction.id} className="slg-auction-row">
+                    <button
+                      type="button"
+                      className="slg-auction-piece"
+                      onClick={() => navigate(`/auctions/${auction.id}`)}
+                    >
+                      <span className="slg-sale-thumb">
+                        {image ? <img src={image} alt="" /> : null}
+                      </span>
+
+                      <span className="slg-sale-identity">
+                        <span className="slg-sale-title">{auction.title}</span>
+                        <span className="slg-sale-buyer">
+                          {isClosed ? 'Winner' : 'High bidder'}: {winnerName || 'No bids'}
+                        </span>
+                      </span>
+
+                      <span className="slg-sale-price">
+                        {highBid ? formatMoney(highBid) : 'No bids'}
+                      </span>
+                    </button>
+
+                    <div className="slg-auction-state">
+                      {isClosed ? (
+                        <SaleStages completedCount={completedStages} />
+                      ) : (
+                        <span className="slg-auction-live">Live</span>
+                      )}
+
+                      {isClosed && (
+                        <div className="slg-auction-actions">
+                          <button
+                            type="button"
+                            className={`slg-sales-button${auction.isPaid ? '' : ' slg-sales-button--primary'}`}
+                            onClick={() => handleTogglePaid(auction.id, auction.isPaid)}
+                          >
+                            {auction.isPaid ? 'Mark unpaid' : 'Mark paid'}
+                          </button>
+
+                          {auction.isPaid && (
+                            <button
+                              type="button"
+                              className="slg-sales-button"
+                              onClick={() => openTrackingModal(auction.id, auction.trackingNumber)}
+                            >
+                              {hasRealTracking(auction.trackingNumber)
+                                ? `Tracking ···${String(auction.trackingNumber).slice(-4)}`
+                                : 'Add tracking'}
+                            </button>
+                          )}
+
+                          {hasRealTracking(auction.trackingNumber) && (
+                            <a
+                              className="slg-sales-button"
+                              href={`https://tools.usps.com/go/TrackConfirmAction?tLabels=${encodeURIComponent(
+                                auction.trackingNumber
+                              )}`}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                            >
+                              Track with USPS
+                            </a>
+                          )}
+                        </div>
+                      )}
+                    </div>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </main>
+      </div>
+
+      {showTrackingModal && (
+        <div className="slg-modal-scrim">
+          <div className="slg-modal" role="dialog" aria-modal="true">
+            <div className="slg-modal-head">
+              <h2 className="slg-modal-title">Add tracking</h2>
+              <button
+                type="button"
+                className="slg-modal-close"
+                onClick={() => setShowTrackingModal(false)}
+                aria-label="Close tracking form"
+              >
+                ✕
+              </button>
+            </div>
+
+            <div className="slg-user-card">
+              <span className="slg-sale-fact-label">Ship to</span>
               {address ? (
-                <div style={{ lineHeight: 1.4 }}>
-                  <div>{displayName || 'Unknown'}</div>
-                  <div>{address.addressLine1}</div>
-                  {address.addressLine2 ? <div>{address.addressLine2}</div> : null}
-                  <div>
-                    {address.city}, {address.state} {address.postalCode}
+                <div className="slg-sale-address">
+                  <div className="slg-sale-address-lines">
+                    <div>{displayName || 'Unknown'}</div>
+                    <div>{address.addressLine1}</div>
+                    {address.addressLine2 ? <div>{address.addressLine2}</div> : null}
+                    <div>
+                      {address.city}, {address.state} {address.postalCode}
+                    </div>
+                    <div>{address.countryCode || 'US'}</div>
                   </div>
-                  <div>{address.countryCode || 'US'}</div>
+                  <button type="button" className="slg-sales-button" onClick={copyAddressText}>
+                    Copy address
+                  </button>
                 </div>
               ) : (
-                <div style={{ color: '#ccc', fontStyle: 'italic' }}>
+                <p className="slg-sale-fact-value slg-sale-fact-value--missing">
                   No shipping address on file
-                </div>
+                </p>
               )}
             </div>
 
-            <input
-              type="text"
-              placeholder="USPS Tracking Number"
-              value={trackingInput}
-              onChange={(e) => setTrackingInput(e.target.value)}
-              style={{
-                padding: '8px',
-                borderRadius: '4px',
-                border: '1px solid #555',
-                background: '#111',
-                color: 'white',
-              }}
-            />
+            <div className="slg-field">
+              <label className="slg-field-label" htmlFor="slg-auction-tracking">
+                USPS tracking number
+              </label>
+              <input
+                id="slg-auction-tracking"
+                type="text"
+                className="slg-input"
+                value={trackingInput}
+                onChange={(e) => setTrackingInput(e.target.value)}
+              />
+            </div>
 
-            <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+            <div className="slg-modal-actions">
               <button
+                type="button"
+                className="slg-sales-button slg-sales-button--wide"
                 onClick={() => setShowTrackingModal(false)}
-                style={{
-                  padding: '6px 12px',
-                  background: '#444',
-                  border: 'none',
-                  borderRadius: '4px',
-                  cursor: 'pointer',
-                  color: 'white',
-                }}
               >
                 Cancel
               </button>
-
               <button
+                type="button"
+                className="slg-sales-button slg-sales-button--primary slg-sales-button--wide"
                 onClick={handleSaveTracking}
-                style={{
-                  padding: '6px 12px',
-                  background: '#2a2',
-                  border: 'none',
-                  borderRadius: '4px',
-                  cursor: 'pointer',
-                  color: 'white',
-                }}
               >
-                Save
+                Save tracking
               </button>
             </div>
           </div>
         </div>
       )}
-    </aside>
+    </>
   );
-}
+};
+
+export default AuctionResultsPanel;

--- a/src/components/Admin/AdminSales/GallerySalesPanel.js
+++ b/src/components/Admin/AdminSales/GallerySalesPanel.js
@@ -10,8 +10,22 @@ import {
 } from '../../../services/fetch-sales.js';
 import { getAllUsers } from '../../../services/fetch-utils.js';
 import { usePosts } from '../../../hooks/usePosts.js';
+import SaleStages from './SaleStages.js';
+import { countCompletedStages, hasRealTracking } from './saleStatus.js';
 
-export default function GallerySalesPanel() {
+const formatMoney = (amount) => `$${Number(amount || 0).toLocaleString()}`;
+
+const getInitial = (...candidates) => {
+  const source = candidates.find(Boolean) || '?';
+  return source.charAt(0).toUpperCase();
+};
+
+const getFullName = (user) => {
+  const profile = user?.profile || {};
+  return `${profile.firstName || 'Unknown'} ${profile.lastName || ''}`.trim();
+};
+
+const GallerySalesPanel = () => {
   const location = useLocation();
   const [sales, setSales] = useState([]);
   const [selectedSale, setSelectedSale] = useState(null);
@@ -71,10 +85,9 @@ export default function GallerySalesPanel() {
   };
 
   // handle selecting an existing sale
-  // At 768px and below the detail panel stacks under a list that is already
-  // 75dvh tall, so whatever opens there lands well below the fold
+
   const revealDetailPanelOnMobile = () => {
-    if (window.matchMedia('(min-width: 769px)').matches) return;
+    if (window.matchMedia('(min-width: 1100px)').matches) return;
     requestAnimationFrame(() => {
       salesPanelRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
     });
@@ -132,11 +145,8 @@ export default function GallerySalesPanel() {
     }
   };
 
-  const handleTrackingClick = (trackingNumber) => {
-    if (!trackingNumber) return;
-    const url = `https://tools.usps.com/go/TrackConfirmAction?tLabels=${encodeURIComponent(trackingNumber)}`;
-    window.open(url, '_blank');
-  };
+  const buildTrackingUrl = (trackingNumber) =>
+    `https://tools.usps.com/go/TrackConfirmAction?tLabels=${encodeURIComponent(trackingNumber)}`;
 
   // Copy helper for currently selected sale's buyer address
   const handleCopyCurrentSaleAddress = () => {
@@ -352,6 +362,7 @@ export default function GallerySalesPanel() {
       }
     }
   };
+
   const handleSearchByEmail = () => {
     if (!newBuyerEmail) return;
     const emailLower = newBuyerEmail.toLowerCase();
@@ -365,6 +376,30 @@ export default function GallerySalesPanel() {
     if (match) {
       handleSelectUser(match);
     }
+  };
+
+  const handleTogglePaid = async () => {
+    try {
+      await updateSalePaidStatus(currentSale.id, !currentSale.is_paid);
+      await loadSales();
+    } catch (e) {
+      toast.error(`${e.message}` || 'Error updating payment status', {
+        theme: 'colored',
+        draggable: true,
+        draggablePercent: 60,
+        toastId: 'admin-sales-paid-1',
+        autoClose: 3000,
+      });
+    }
+  };
+
+  const handleStartNewSale = () => {
+    setSelectedSale(null);
+    setIsCreatingSale(true);
+    setSelectedUser(null);
+    setSearchTerm('');
+    setDebouncedTerm('');
+    revealDetailPanelOnMobile();
   };
 
   // the one new refactor line
@@ -408,110 +443,189 @@ export default function GallerySalesPanel() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [location.state, users, prefillApplied]);
 
-  // Helper function to determine border color based on payment and shipping status
-  const getSaleBorderColor = (sale) => {
-    // Not paid and no tracking = red
-    if (!sale.is_paid && (!sale.tracking_number || sale.tracking_number === '0')) {
-      return 'red';
-    }
-    // Paid but no tracking = yellow
-    if (sale.is_paid && (!sale.tracking_number || sale.tracking_number === '0')) {
-      return 'yellow';
-    }
-    // Paid and has tracking = green
-    if (sale.is_paid && sale.tracking_number && sale.tracking_number !== '0') {
-      return 'green';
-    }
-    // Default fallback
-    return '#333';
-  };
+  const stageCounts = sales.reduce(
+    (totals, sale) => {
+      const completed = countCompletedStages({
+        isPaid: sale.is_paid,
+        trackingNumber: sale.tracking_number,
+      });
+      if (completed === 1) totals.awaitingPayment += 1;
+      if (completed === 2) totals.readyToShip += 1;
+      totals.gross += Number(sale.price) || 0;
+      return totals;
+    },
+    { awaitingPayment: 0, readyToShip: 0, gross: 0 }
+  );
+
+  const statTiles = [
+    { label: 'Sales', value: sales.length },
+    {
+      label: 'Unpaid',
+      value: stageCounts.awaitingPayment,
+      tone: stageCounts.awaitingPayment > 0 ? 'bad' : null,
+    },
+    {
+      label: 'To ship',
+      value: stageCounts.readyToShip,
+      tone: stageCounts.readyToShip > 0 ? 'wait' : null,
+    },
+    { label: 'Gross', value: formatMoney(stageCounts.gross) },
+  ];
+
+  const currentSaleStages = currentSale
+    ? countCompletedStages({
+        isPaid: currentSale.is_paid,
+        trackingNumber: currentSale.tracking_number,
+      })
+    : 1;
+
+  const buyerUserForCurrentSale = currentSale
+    ? users.find(
+        (u) =>
+          (u.email || u.user_email || '').toLowerCase() ===
+          (currentSale.buyer_email || '').toLowerCase()
+      )
+    : null;
+  const currentSaleAddress = buyerUserForCurrentSale?.address;
+
+  const renderUserIdentity = (user) => (
+    <>
+      {user.profile?.imageUrl || user.profile?.image_url ? (
+        <img
+          src={user.profile.imageUrl || user.profile.image_url}
+          alt=""
+          className="slg-user-avatar"
+        />
+      ) : (
+        <div className="slg-user-avatar slg-user-avatar--fallback" aria-hidden="true">
+          {getInitial(user.profile?.firstName, user.email, user.user_email)}
+        </div>
+      )}
+      <span className="slg-user-meta">
+        <span className="slg-user-name">{getFullName(user)}</span>
+        <span className="slg-user-email">{user.email || user.user_email}</span>
+      </span>
+    </>
+  );
+
+  const renderAddressLines = (address) => (
+    <div className="slg-sale-address-lines">
+      <div>{address.addressLine1}</div>
+      {address.addressLine2 ? <div>{address.addressLine2}</div> : null}
+      <div>
+        {address.city}, {address.state} {address.postalCode}
+      </div>
+      <div>{address.countryCode || 'US'}</div>
+    </div>
+  );
 
   return (
-    <div>
-      <div className="admin-sales-container">
-        <div className="admin-sales-content">
-          <div className="sales-header">
-            <h3>Gallery Sales</h3>
+    <>
+      <div className="slg-sales-stats">
+        {statTiles.map((tile) => (
+          <div
+            key={tile.label}
+            className={`slg-sales-stat${tile.tone ? ` slg-sales-stat--${tile.tone}` : ''}`}
+          >
+            <span className="slg-sales-stat-label">{tile.label}</span>
+            <span className="slg-sales-stat-value">{tile.value}</span>
+          </div>
+        ))}
+      </div>
+
+      <div className="slg-sales-body">
+        <main className="slg-sales-main">
+          <div className="slg-sales-toolbar">
+            <h2 className="slg-sales-heading">Gallery sales</h2>
 
             <button
-              className="add-sale-button"
-              onClick={() => {
-                setSelectedSale(null);
-                setIsCreatingSale(true);
-                setSelectedUser(null);
-                setSearchTerm('');
-                setDebouncedTerm('');
-                revealDetailPanelOnMobile();
-              }}
+              type="button"
+              className="slg-sales-button slg-sales-button--primary"
+              onClick={handleStartNewSale}
             >
-              Add Sale
+              Add sale
             </button>
+
+            <p className="slg-sales-count">{sales.length}</p>
           </div>
 
-          <div className="sales-layout">
-            {/* Sales list */}
-            <div className="sales-list">
-              {loading ? (
-                <div className="loading-sales">
-                  <p>Loading sales...</p>
-                </div>
-              ) : sales.length === 0 ? (
-                <div className="no-sales">
-                  <p>No sales yet</p>
-                </div>
-              ) : (
-                <div className="sales-items">
-                  {sales.map((sale) => (
-                    <div
-                      key={sale.id}
-                      className={`sales-item ${selectedSale === sale.id ? 'selected' : ''}`}
-                      onClick={() => handleSelectSale(sale.id)}
-                      style={{ border: `2px solid ${getSaleBorderColor(sale)}` }}
-                    >
-                      <div className="sales-item-img-wrapper">
-                        <img
-                          src={sale.image_url}
-                          alt={sale.post_title}
-                          className="sales-item-img"
-                        />
-                      </div>
+          {(() => {
+            if (loading) {
+              return <p className="slg-sale-empty">Loading sales…</p>;
+            }
+            if (sales.length === 0) {
+              return (
+                <p className="slg-sale-empty">
+                  No gallery sales yet. Add one to start tracking payment and shipping.
+                </p>
+              );
+            }
+            return (
+              <ul className="slg-sale-list">
+                {sales.map((sale) => {
+                  const completedStages = countCompletedStages({
+                    isPaid: sale.is_paid,
+                    trackingNumber: sale.tracking_number,
+                  });
+                  return (
+                    <li key={sale.id}>
+                      <button
+                        type="button"
+                        className={`slg-sale-row${selectedSale === sale.id ? ' slg-sale-row--on' : ''}`}
+                        aria-pressed={selectedSale === sale.id}
+                        onClick={() => handleSelectSale(sale.id)}
+                      >
+                        <span className="slg-sale-thumb">
+                          <img src={sale.image_url} alt="" />
+                        </span>
 
-                      <div className="sales-item-info">
-                        <span className="sales-post-title">{sale.post_title}</span>
-
-                        <div className="sales-item-meta">
-                          <span>${sale.price}</span>
-                          <span>{sale.buyer_email}</span>
-                        </div>
-
-                        <div className="sales-item-meta">
-                          <span>
-                            <strong>{sale.buyer_first_name}</strong>{' '}
-                            {sale.buyer_last_name?.length > 30
-                              ? sale.buyer_last_name?.slice(0, 4) + '...'
-                              : sale.buyer_last_name}
+                        <span className="slg-sale-identity">
+                          <span className="slg-sale-title">{sale.post_title}</span>
+                          <span className="slg-sale-buyer">
+                            {`${sale.buyer_first_name || ''} ${sale.buyer_last_name || ''}`.trim()}
+                            {' · '}
+                            {sale.buyer_email}
                           </span>
-                        </div>
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              )}
-            </div>
+                        </span>
 
-            {/* Sale detail panel */}
-            <div className="sales-panel" ref={salesPanelRef}>
-              {isCreatingSale ? (
-                <div className="sales-detail">
-                  <h2>Create New Sale</h2>
-                  {/* Customer search */}
-                  <div className="sales-detail-row" style={{ alignItems: 'flex-start' }}>
-                    <label>Find Customer:</label>
-                    <div style={{ position: 'relative' }}>
+                        <span className="slg-sale-price">{formatMoney(sale.price)}</span>
+
+                        <SaleStages completedCount={completedStages} />
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+            );
+          })()}
+        </main>
+
+        <aside className="slg-sales-rail" ref={salesPanelRef}>
+          {(() => {
+            if (isCreatingSale) {
+              return (
+                <div className="slg-sale-panel">
+                  <div className="slg-sale-panel-head">
+                    <h2 className="slg-sale-panel-title">New sale</h2>
+                    <button
+                      type="button"
+                      className="slg-sales-button"
+                      onClick={() => setIsCreatingSale(false)}
+                    >
+                      Cancel
+                    </button>
+                  </div>
+
+                  <div className="slg-sale-panel-body">
+                    <div className="slg-field slg-user-search">
+                      <label className="slg-field-label" htmlFor="slg-customer-search">
+                        Find customer
+                      </label>
                       <input
+                        id="slg-customer-search"
                         type="text"
-                        className="tracking-input"
-                        placeholder="Type name or email..."
+                        className="slg-input"
+                        placeholder="Name or email"
                         value={searchTerm}
                         onChange={(e) => {
                           setSearchTerm(e.target.value);
@@ -520,461 +634,300 @@ export default function GallerySalesPanel() {
                         onFocus={() => setShowUserResults(true)}
                       />
                       {showUserResults && debouncedTerm && (
-                        <div className="user-search-results" role="listbox">
+                        <div className="slg-user-results">
                           {filteredUsers.length === 0 ? (
-                            <div className="user-result-item empty">No users found</div>
+                            <p className="slg-user-results-empty">No customers match that.</p>
                           ) : (
-                            filteredUsers.map((u) => (
-                              <div
-                                key={u.id}
-                                className="user-result-item"
-                                role="option"
-                                onClick={() => handleSelectUser(u)}
+                            filteredUsers.map((user) => (
+                              <button
+                                key={user.id}
+                                type="button"
+                                className="slg-user-result"
+                                onClick={() => handleSelectUser(user)}
                               >
-                                {u.profile?.imageUrl || u.profile?.image_url ? (
-                                  <img
-                                    src={u.profile.imageUrl || u.profile.image_url}
-                                    alt="avatar"
-                                    className="user-avatar"
-                                  />
-                                ) : (
-                                  <div className="user-avatar-fallback">
-                                    {(u.profile?.firstName || u.email || u.user_email || '?')
-                                      .charAt(0)
-                                      .toUpperCase()}
-                                  </div>
-                                )}
-                                <div className="user-meta">
-                                  <div className="user-name">
-                                    {(u.profile?.firstName || 'Unknown') +
-                                      ' ' +
-                                      (u.profile?.lastName || '')}
-                                  </div>
-                                  <div className="user-email">{u.email || u.user_email}</div>
-                                </div>
-                              </div>
+                                {renderUserIdentity(user)}
+                              </button>
                             ))
                           )}
                         </div>
                       )}
                     </div>
-                  </div>
-                  {/* Selected customer summary */}
-                  {selectedUser && (
-                    <div className="selected-user-card">
-                      <div className="selected-user-header">
-                        {selectedUser.profile?.imageUrl || selectedUser.profile?.image_url ? (
-                          <img
-                            src={selectedUser.profile.imageUrl || selectedUser.profile.image_url}
-                            alt="avatar"
-                            className="user-avatar"
-                          />
-                        ) : (
-                          <div className="user-avatar-fallback">
-                            {(selectedUser.profile?.firstName || selectedUser.email || '?')
-                              .charAt(0)
-                              .toUpperCase()}
-                          </div>
-                        )}
-                        <div className="user-meta">
-                          <div className="user-name">
-                            {(selectedUser.profile?.firstName || 'Unknown') +
-                              ' ' +
-                              (selectedUser.profile?.lastName || '')}
-                          </div>
-                          <div className="user-email">{selectedUser.email}</div>
-                        </div>
-                      </div>
-                      <div className="selected-user-address">
-                        <div className="selected-user-address-actions">
-                          <button
-                            type="button"
-                            className="copy-address-button"
-                            onClick={handleCopyAddress}
-                            disabled={!selectedUser.address}
-                          >
-                            Copy
-                          </button>
-                        </div>
+
+                    {selectedUser && (
+                      <div className="slg-user-card">
+                        <div className="slg-user-identity">{renderUserIdentity(selectedUser)}</div>
+
                         {selectedUser.address ? (
-                          <div className="address-lines">
-                            <div>{selectedUser.address.addressLine1}</div>
-                            {selectedUser.address.addressLine2 ? (
-                              <div>{selectedUser.address.addressLine2}</div>
-                            ) : null}
-                            <div>
-                              {selectedUser.address.city}, {selectedUser.address.state}{' '}
-                              {selectedUser.address.postalCode}
-                            </div>
-                            <div>{selectedUser.address.countryCode || 'US'}</div>
+                          <div className="slg-sale-address">
+                            {renderAddressLines(selectedUser.address)}
+                            <button
+                              type="button"
+                              className="slg-sales-button"
+                              onClick={handleCopyAddress}
+                            >
+                              Copy address
+                            </button>
                           </div>
                         ) : (
-                          <div className="address-missing">No shipping address on file</div>
+                          <p className="slg-sale-fact-value slg-sale-fact-value--missing">
+                            No shipping address on file
+                          </p>
                         )}
                       </div>
-                    </div>
-                  )}
-                  <div className="sales-detail-row">
-                    <label>Buyer Email:</label>
-                    <div style={{ display: 'flex', alignItems: 'center', gap: '.5rem' }}>
+                    )}
+
+                    <div className="slg-field">
+                      <label className="slg-field-label" htmlFor="slg-buyer-email">
+                        Buyer email
+                      </label>
                       <input
+                        id="slg-buyer-email"
                         type="text"
-                        className="tracking-input"
+                        className="slg-input"
                         value={newBuyerEmail}
                         onChange={(e) => setNewBuyerEmail(e.target.value)}
                       />
-
                       <button
                         type="button"
+                        className="slg-sales-button"
                         onClick={handleSearchByEmail}
-                        className="search-email-button"
-                        aria-label="Use email to find user"
                       >
-                        Find User
+                        Find user by email
+                      </button>
+                    </div>
+
+                    <div className="slg-field">
+                      <label className="slg-field-label" htmlFor="slg-piece-id">
+                        Piece ID
+                      </label>
+                      <input
+                        id="slg-piece-id"
+                        type="number"
+                        className="slg-input"
+                        value={newPieceId}
+                        onChange={(e) => setNewPieceId(e.target.value)}
+                      />
+                      <button
+                        type="button"
+                        className="slg-sales-button"
+                        onClick={() => setShowPostModal(true)}
+                      >
+                        Find post
+                      </button>
+                    </div>
+
+                    <div className="slg-field">
+                      <label className="slg-field-label" htmlFor="slg-sale-price">
+                        Price
+                      </label>
+                      <span className="slg-input-money">
+                        <input
+                          id="slg-sale-price"
+                          type="number"
+                          className="slg-input"
+                          value={newPrice}
+                          onChange={(e) => setNewPrice(e.target.value)}
+                        />
+                      </span>
+                    </div>
+
+                    <div className="slg-field">
+                      <label className="slg-field-label" htmlFor="slg-new-tracking">
+                        Tracking number
+                      </label>
+                      <input
+                        id="slg-new-tracking"
+                        type="text"
+                        className="slg-input"
+                        value={newTracking}
+                        onChange={(e) => setNewTracking(e.target.value)}
+                      />
+                    </div>
+
+                    <div className="slg-sale-actions">
+                      <button
+                        type="button"
+                        className="slg-sales-button slg-sales-button--primary slg-sales-button--wide"
+                        onClick={handleCreateSale}
+                      >
+                        Save sale
                       </button>
                     </div>
                   </div>
-                  <div className="sales-detail-row">
-                    <label style={{ display: 'flex', alignItems: 'center', gap: '.5rem' }}>
-                      Piece ID:
+                </div>
+              );
+            }
+
+            if (!currentSale) {
+              return (
+                <div className="slg-sale-panel">
+                  <div className="slg-sale-panel-head">
+                    <h2 className="slg-sale-panel-title">Sale detail</h2>
+                  </div>
+                  <p className="slg-sale-placeholder">
+                    Pick a sale to see the buyer, the address, and where it is in the pipeline.
+                  </p>
+                </div>
+              );
+            }
+
+            return (
+              <div className="slg-sale-panel">
+                <div className="slg-sale-panel-head">
+                  <h2 className="slg-sale-panel-title">Sale detail</h2>
+                  <button
+                    type="button"
+                    className="slg-sales-button"
+                    onClick={() => setSelectedSale(null)}
+                  >
+                    Close
+                  </button>
+                </div>
+
+                <div className="slg-sale-panel-body">
+                  <SaleStages completedCount={currentSaleStages} variant="detail" />
+
+                  <div className="slg-sale-piece">
+                    <img src={currentSale.image_url} alt="" className="slg-sale-piece-image" />
+                    <div className="slg-sale-piece-meta">
+                      <h3 className="slg-sale-piece-title">{currentSale.post_title}</h3>
+                      <span className="slg-sale-piece-price">{formatMoney(currentSale.price)}</span>
+                    </div>
+                  </div>
+
+                  <div className="slg-sale-actions">
+                    <button
+                      type="button"
+                      className="slg-sales-button slg-sales-button--wide"
+                      onClick={handleTogglePaid}
+                    >
+                      {currentSale.is_paid ? 'Mark unpaid' : 'Mark paid'}
+                    </button>
+                  </div>
+
+                  <dl className="slg-sale-facts">
+                    <div className="slg-sale-fact">
+                      <dt className="slg-sale-fact-label">Buyer</dt>
+                      <dd className="slg-sale-fact-value">
+                        {currentSale.buyer_first_name} {currentSale.buyer_last_name?.slice(0, 1)}.
+                      </dd>
+                    </div>
+
+                    <div className="slg-sale-fact">
+                      <dt className="slg-sale-fact-label">Email</dt>
+                      <dd className="slg-sale-fact-value">{currentSale.buyer_email}</dd>
+                    </div>
+
+                    <div className="slg-sale-fact">
+                      <dt className="slg-sale-fact-label">Ship to</dt>
+                      <dd className="slg-sale-fact-value">
+                        {currentSaleAddress ? (
+                          <div className="slg-sale-address">
+                            {renderAddressLines(currentSaleAddress)}
+                            <button
+                              type="button"
+                              className="slg-sales-button"
+                              onClick={handleCopyCurrentSaleAddress}
+                            >
+                              Copy address
+                            </button>
+                          </div>
+                        ) : (
+                          <span className="slg-sale-fact-value--missing">
+                            No shipping address on file
+                          </span>
+                        )}
+                      </dd>
+                    </div>
+                  </dl>
+
+                  {hasRealTracking(currentSale.tracking_number) && (
+                    <a
+                      className="slg-sale-tracking-link"
+                      href={buildTrackingUrl(currentSale.tracking_number)}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      <img alt="" className="slg-sale-tracking-mark" src="../../../usps.png" />
+                      <span className="slg-sale-tracking-text">
+                        <span className="slg-sale-tracking-caption">Track with USPS</span>
+                        <span className="slg-sale-tracking-number">
+                          {currentSale.tracking_number}
+                        </span>
+                      </span>
+                    </a>
+                  )}
+
+                  <div className="slg-field">
+                    <label className="slg-field-label" htmlFor="slg-sale-tracking">
+                      Tracking number
                     </label>
                     <input
-                      type="number"
-                      className="tracking-input"
-                      value={newPieceId}
-                      onChange={(e) => setNewPieceId(e.target.value)}
-                    />
-                    <button
-                      type="button"
-                      onClick={() => setShowPostModal(true)}
-                      className="search-post-button"
-                      aria-label="Click to find post"
-                    >
-                      Find Post
-                    </button>
-                  </div>
-                  {/* Post Finder Modal */}
-                  {showPostModal && (
-                    <div
-                      className="find-post-modal"
-                      style={{
-                        position: 'fixed',
-                        top: 0,
-                        left: 0,
-                        width: '100vw',
-                        height: '100vh',
-                        background: 'rgba(0,0,0,0.45)',
-                        zIndex: 1000,
-                        display: 'flex',
-                        alignItems: 'center',
-                        justifyContent: 'center',
-                      }}
-                    >
-                      <div
-                        style={{
-                          background: '#1a1a1aff',
-                          borderRadius: '8px',
-                          padding: '2rem',
-                          maxHeight: '80vh',
-                          overflowY: 'auto',
-                          minWidth: '320px',
-                          maxWidth: '95vw',
-                          boxShadow: '0 2px 16px rgba(0,0,0,0.18)',
-                          position: 'relative',
-                        }}
-                      >
-                        <button
-                          style={{
-                            position: 'absolute',
-                            top: 10,
-                            right: 10,
-                            fontSize: '1.2em',
-                            background: 'none',
-                            border: 'none',
-                            cursor: 'pointer',
-                          }}
-                          onClick={() => setShowPostModal(false)}
-                          aria-label="Close post finder"
-                        >
-                          ×
-                        </button>
-                        <h3 style={{ marginTop: 0 }}>Select a Post</h3>
-                        <div
-                          style={{
-                            display: 'grid',
-                            gridTemplateColumns: 'repeat(auto-fit, minmax(160px, 1fr))',
-                            gap: '1rem',
-                            marginTop: '1rem',
-                          }}
-                        >
-                          {(() => {
-                            if (posts && posts.length > 0) {
-                              return posts.map((post) => {
-                                const price = getPostPrice(post);
-                                let imageSrc = '';
-                                if (post.image_url) {
-                                  imageSrc = post.image_url;
-                                } else if (post.imageUrl) {
-                                  imageSrc = post.imageUrl;
-                                }
-                                return (
-                                  <div
-                                    key={post.id}
-                                    className="find-post-card"
-                                    style={{
-                                      border: '1px solid #ccc',
-                                      borderRadius: '6px',
-                                      padding: '0.5rem ',
-                                      cursor: 'pointer',
-                                      background: '#0f0f0fff',
-                                      display: 'flex',
-                                      flexDirection: 'row',
-                                      alignItems: 'center',
-                                      transition: 'box-shadow 0.2s',
-                                      maxWidth: '300px',
-                                    }}
-                                    onClick={() => handleSelectPost(post)}
-                                    tabIndex={0}
-                                    onKeyDown={(e) => {
-                                      if (e.key === 'Enter') handleSelectPost(post);
-                                    }}
-                                  >
-                                    <img
-                                      src={imageSrc}
-                                      alt={post.title}
-                                      style={{
-                                        width: '90px',
-                                        height: '90px',
-                                        objectFit: 'cover',
-                                        borderRadius: '4px',
-                                        background: '#eee',
-                                      }}
-                                    />
-                                    <div
-                                      style={{
-                                        display: 'flex',
-                                        flexDirection: 'column',
-                                        fontWeight: 600,
-                                        fontSize: '1em',
-                                        textAlign: 'center',
-                                        margin: '.25em',
-                                        // width: '100%',
-                                        overflow: 'hidden',
-                                        textOverflow: 'ellipsis',
-                                        whiteSpace: 'nowrap',
-                                      }}
-                                    >
-                                      {post.title}
-                                      <div style={{ fontSize: '.95em', color: '#555' }}>
-                                        ID: {post.id}
-                                      </div>
-                                      <div style={{ fontSize: '.95em', color: '#555' }}>
-                                        ${price}
-                                      </div>
-                                    </div>
-                                  </div>
-                                );
-                              });
-                            } else {
-                              return <div>No posts found.</div>;
-                            }
-                          })()}
-                        </div>
-                      </div>
-                    </div>
-                  )}
-                  <div className="sales-detail-row">
-                    <label>Price:</label>
-                    <input
-                      type="number"
-                      className="tracking-input"
-                      value={newPrice}
-                      onChange={(e) => setNewPrice(e.target.value)}
-                    />
-                  </div>
-                  <div className="sales-detail-row">
-                    <label>Tracking Number:</label>
-                    <input
+                      id="slg-sale-tracking"
                       type="text"
-                      className="tracking-input"
-                      value={newTracking}
-                      onChange={(e) => setNewTracking(e.target.value)}
-                    />
-                  </div>
-                  <div className="mobile-button-wrapper">
-                    <button
-                      type="button"
-                      onClick={handleSearchByEmail}
-                      className="search-email-button-mobile"
-                      aria-label="Use email to find user"
-                    >
-                      Find User
-                    </button>{' '}
-                    <button
-                      type="button"
-                      onClick={() => setShowPostModal(true)}
-                      className="search-post-button-mobile"
-                      aria-label="Click to find post"
-                    >
-                      Find Post
-                    </button>
-                  </div>
-
-                  <button className="save-tracking-button" onClick={handleCreateSale}>
-                    Save Sale
-                  </button>
-                  <button className="cancel-button" onClick={() => setIsCreatingSale(false)}>
-                    Cancel
-                  </button>
-                </div>
-              ) : !currentSale ? (
-                <div className="no-sale-selected">
-                  <p>Select a sale to view details</p>
-                </div>
-              ) : (
-                <div className="sales-detail">
-                  <img src={currentSale.image_url} alt="Piece" className="sales-detail-img" />
-
-                  {currentSale.tracking_number && currentSale.tracking_number !== '0' && (
-                    <div
-                      className="tracking-link"
-                      onClick={() => handleTrackingClick(currentSale.tracking_number)}
-                      role="button"
-                      tabIndex={0}
-                      onKeyDown={(e) => {
-                        if (e.key === 'Enter') handleTrackingClick(currentSale.tracking_number);
-                      }}
-                    >
-                      <img
-                        alt="USPS"
-                        className="auction-result-thumb"
-                        style={{ width: '50px', height: '50px', margin: '.5rem 0 0 .25rem' }}
-                        src="../../../usps.png"
-                      />
-
-                      <p style={{ textAlign: 'left', margin: 0 }}>
-                        <span>Tracking number:</span>
-                        <br />
-                        <span>{currentSale.tracking_number}</span>
-                      </p>
-                    </div>
-                  )}
-
-                  {/* PAID STATUS + TOGGLE */}
-                  <div className="sales-paid-status">
-                    <div
-                      className="sales-paid-status-indicator"
-                      style={{ backgroundColor: currentSale.is_paid ? 'green' : 'yellow' }}
-                    >
-                      {currentSale.is_paid ? 'Paid' : 'Not Paid'}
-                    </div>
-
-                    <button
-                      className="sale-paid-toggle-button"
-                      style={{
-                        border: '1px solid',
-                        borderColor: currentSale.is_paid ? 'green' : 'yellow',
-                      }}
-                      onClick={async () => {
-                        try {
-                          await updateSalePaidStatus(currentSale.id, !currentSale.is_paid);
-                          await loadSales();
-                        } catch (e) {
-                          toast.error(`${e.message}` || 'Error updating payment status', {
-                            theme: 'colored',
-                            draggable: true,
-                            draggablePercent: 60,
-                            toastId: 'admin-sales-paid-1',
-                            autoClose: 3000,
-                          });
-                        }
-                      }}
-                    >
-                      {currentSale.is_paid ? 'Mark Unpaid' : 'Mark Paid'}
-                    </button>
-                  </div>
-
-                  <div className="sales-detail-row">
-                    <label>Buyer:</label>
-                    <span>{currentSale.buyer_first_name}</span>
-                    <span>{currentSale.buyer_last_name?.slice(0, 1)}.</span>
-                  </div>
-
-                  <div className="sales-detail-row" style={{ alignItems: 'flex-start' }}>
-                    <label>Address:</label>
-                    <div style={{ display: 'flex', flexDirection: 'column', gap: '.5rem' }}>
-                      {/* Resolve buyer user to show address */}
-                      {(() => {
-                        const buyerEmail = (currentSale.buyer_email || '').toLowerCase();
-                        const buyerUser = users.find(
-                          (u) => (u.email || u.user_email || '').toLowerCase() === buyerEmail
-                        );
-                        const address = buyerUser?.address;
-                        if (!address) {
-                          return <div className="address-missing">No shipping address on file</div>;
-                        }
-                        return (
-                          <div className="selected-user-address">
-                            <div className="selected-user-address-actions">
-                              <button
-                                type="button"
-                                className="copy-address-button"
-                                onClick={handleCopyCurrentSaleAddress}
-                                disabled={!address}
-                              >
-                                Copy
-                              </button>
-                            </div>
-                            <div className="address-lines">
-                              <div>{address.addressLine1}</div>
-                              {address.addressLine2 ? <div>{address.addressLine2}</div> : null}
-                              <div>
-                                {address.city}, {address.state} {address.postalCode}
-                              </div>
-                              <div>{address.countryCode || 'US'}</div>
-                            </div>
-                          </div>
-                        );
-                      })()}
-                    </div>
-                  </div>
-
-                  <div className="sales-detail-row">
-                    <label>Email:</label>
-                    <span>{currentSale.buyer_email}</span>
-                  </div>
-
-                  <div className="sales-detail-row">
-                    <label>Piece:</label>
-                    <span>{currentSale.post_title}</span>
-                  </div>
-
-                  <div className="sales-detail-row">
-                    <label>Price:</label>
-                    <span>${currentSale.price}</span>
-                  </div>
-
-                  <div className="sales-detail-row">
-                    <label>Tracking Number:</label>
-                    <input
-                      type="text"
-                      className="tracking-input"
+                      className="slg-input"
                       value={trackingInput}
                       onChange={(e) => setTrackingInput(e.target.value)}
                     />
                   </div>
 
-                  <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
-                    <button className="save-tracking-button" onClick={handleSaveTracking}>
-                      Save Tracking
+                  <div className="slg-sale-actions">
+                    <button
+                      type="button"
+                      className="slg-sales-button slg-sales-button--primary slg-sales-button--wide"
+                      onClick={handleSaveTracking}
+                    >
+                      Save tracking
                     </button>
                   </div>
                 </div>
-              )}
+              </div>
+            );
+          })()}
+        </aside>
+      </div>
+
+      {showPostModal && (
+        <div className="slg-modal-scrim">
+          <div className="slg-modal slg-modal--wide" role="dialog" aria-modal="true">
+            <div className="slg-modal-head">
+              <h2 className="slg-modal-title">Select a piece</h2>
+              <button
+                type="button"
+                className="slg-modal-close"
+                onClick={() => setShowPostModal(false)}
+                aria-label="Close piece finder"
+              >
+                ✕
+              </button>
             </div>
+
+            {posts && posts.length > 0 ? (
+              <div className="slg-post-picker">
+                {posts.map((post) => (
+                  <button
+                    key={post.id}
+                    type="button"
+                    className="slg-post-option"
+                    onClick={() => handleSelectPost(post)}
+                  >
+                    <img src={post.image_url || post.imageUrl} alt="" />
+                    <span className="slg-post-option-meta">
+                      <span className="slg-post-option-title">{post.title}</span>
+                      <span className="slg-post-option-sub">ID {post.id}</span>
+                      <span className="slg-post-option-sub">{formatMoney(getPostPrice(post))}</span>
+                    </span>
+                  </button>
+                ))}
+              </div>
+            ) : (
+              <p className="slg-sale-placeholder">No pieces to choose from.</p>
+            )}
           </div>
         </div>
-      </div>
-    </div>
+      )}
+    </>
   );
-}
+};
+
+export default GallerySalesPanel;

--- a/src/components/Admin/AdminSales/SaleStages.js
+++ b/src/components/Admin/AdminSales/SaleStages.js
@@ -1,0 +1,37 @@
+import { SALE_STAGE_NAMES, describeStage, getStageTone } from './saleStatus.js';
+
+const SaleStages = ({ completedCount, variant = 'row' }) => {
+  const toneClass = `slg-stages--${getStageTone(completedCount)}`;
+
+  if (variant === 'detail') {
+    return (
+      <div className={`slg-stages slg-stages--detail ${toneClass}`}>
+        {SALE_STAGE_NAMES.map((stageName, index) => (
+          <div
+            key={stageName}
+            className={`slg-stage-step${index < completedCount ? ' slg-stage-step--done' : ''}`}
+          >
+            <span className="slg-stage-bar" />
+            <span className="slg-stage-name">{stageName}</span>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <span className={`slg-stages ${toneClass}`}>
+      <span className="slg-stage-track" aria-hidden="true">
+        {SALE_STAGE_NAMES.map((stageName, index) => (
+          <span
+            key={stageName}
+            className={`slg-stage-bar${index < completedCount ? ' slg-stage-bar--done' : ''}`}
+          />
+        ))}
+      </span>
+      <span className="slg-stage-status">{describeStage(completedCount)}</span>
+    </span>
+  );
+};
+
+export default SaleStages;

--- a/src/components/Admin/AdminSales/saleStatus.js
+++ b/src/components/Admin/AdminSales/saleStatus.js
@@ -1,0 +1,24 @@
+export const SALE_STAGE_NAMES = ['Sold', 'Paid', 'Shipped'];
+
+const hasRealTracking = (trackingNumber) =>
+  Boolean(trackingNumber) && String(trackingNumber).trim() !== '' && trackingNumber !== '0';
+
+export const countCompletedStages = ({ isPaid, trackingNumber }) => {
+  if (isPaid && hasRealTracking(trackingNumber)) return 3;
+  if (isPaid) return 2;
+  return 1;
+};
+
+export const describeStage = (completedCount) => {
+  if (completedCount >= 3) return 'Shipped';
+  if (completedCount === 2) return 'To ship';
+  return 'Unpaid';
+};
+
+export const getStageTone = (completedCount) => {
+  if (completedCount >= 3) return 'good';
+  if (completedCount === 2) return 'wait';
+  return 'bad';
+};
+
+export { hasRealTracking };

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -28,6 +28,10 @@
      decorative, and never used for "on sale" (that's the flame). */
   --slg-alert: #e5484d;
 
+  --slg-state-bad: #e5484d;
+  --slg-state-wait: #f2c94c;
+  --slg-state-good: #3fc77f;
+
   /* rhythm */
   --slg-gutter: clamp(1.25rem, 4vw, 4rem);
 


### PR DESCRIPTION
# Redesign Admin Sales screens with shared design system and sale pipeline

## Summary
Rebuilds the Gallery Sales and Auction Results admin screens to use the site's shared `slg-*` design tokens and components instead of bespoke, largely inline-styled markup. Replaces the old red/yellow/green border-as-status-indicator with a shared `Sold → Paid → Shipped` pipeline component driven by one state model, so the stat tiles and the row indicators can never disagree.

## Changes
- **New shared sale-state module**: `saleStatus.js` adds `countCompletedStages`, `describeStage`, `getStageTone`, and `hasRealTracking` — a single definition of what stage a sale (gallery or auction) is in, based on `isPaid` and `trackingNumber`.
- **New shared pipeline component**: `SaleStages.js` renders the three-segment indicator in two variants — inline (`row`) for list rows and expanded (`detail`) for the detail panel.
- **Design tokens**: `tokens.css` adds `--slg-state-bad` / `--slg-state-wait` / `--slg-state-good`, scoped to admin screens only.
- **AdminSales.js / AdminSales.css**: shell rebuilt onto `slg-sales-*` classes (eyebrow + title head, segmented tab control with proper `role="tablist"`/`aria-selected` wiring, `const` component instead of `function`).
- **GallerySalesPanel.js / GallerySalesPanel.css (via AdminSales.css)**: full re-layout — stat strip (sales count, unpaid, to-ship, gross), toolbar, row list, and a sticky detail rail (was a fixed-width flex layout with a `75dvh` inner scroller). Customer search, address display, and the post-picker modal are all rebuilt onto shared `slg-field`/`slg-modal`/`slg-user-*` classes. Buyer name truncation and border-color status logic are removed in favor of `SaleStages`.
- **AuctionResultsPanel.js / AuctionResultsPanel.css**: same treatment — stat tiles (results, unpaid, to-ship, owed), row list with piece link + inline paid/tracking/USPS actions, and the tracking modal rebuilt onto `slg-modal`. Inline `style={{}}` throughout is removed.

## Testing
No test files were touched in this change set. Manual verification needed for: tab switching between Gallery/Auction views, sale/auction row selection and detail rail behavior at mobile (<1100px) and desktop widths, stat tile tone thresholds (unpaid/to-ship > 0), customer search and address copy, tracking modal save flow, and the post-picker modal.